### PR TITLE
chore: Update pyproject.toml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 install-dev:
 	python3 -m pip install -U pip
-	python3 -m pip install -r requirements/requirements-dev.txt
+	python3 -m pip install -e . --group dev
 
 clean:
 	rm -rf build

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ check:
 	ruff format mahjax --check
 	blackdoc mahjax --check
 	ruff check mahjax
-	mypy --config pyproject.toml mahjax --ignore-missing-imports
+	mypy mahjax
 
 install:
 	python3 -m pip install -U pip setuptools

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -9,7 +9,7 @@ pip install mahjax
 uvicorn mahjax.ui.app:create_app --host 0.0.0.0 --port 8000
 ```
 
-You need Python 3.10+, a matching JAX wheel (install it beforehand), and the runtime deps listed in `requirements.txt` (`fastapi`, `uvicorn`, `svgwrite`, `typing_extensions`). Use `--reload` while developing but turn it off in production.
+You need Python 3.10+. Use `--reload` while developing but turn it off in production.
 
 ## Core Features
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dev = [
     { include-group = "lint" },
     { include-group = "typing" },
     { include-group = "test" },
+    { include-group = "coverage" },
     { include-group = "docs" },
 ]
 lint = [
@@ -58,8 +59,10 @@ typing = [
 ]
 test = [
     "pytest>=8.4.2",
-    "pytest-cov>=7.0.0",
     "pytest-xdist>=3.8.0",
+]
+coverage = [
+    "pytest-cov>=7.0.0",
 ]
 docs = [
     "mkdocs>=1.6.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,11 @@ test = [
     "pytest-cov>=7.0.0",
     "pytest-xdist>=3.8.0",
 ]
+docs = [
+    "mkdocs>=1.6.1",
+    "mkdocs-material>=9.7.1",
+    "mkdocstrings[python]>=0.30.1",
+]
 
 [tool.black]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dev = [
     { include-group = "lint" },
     { include-group = "typing" },
     { include-group = "test" },
+    { include-group = "docs" },
 ]
 lint = [
     "blackdoc>=0.3.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,11 +55,3 @@ ignore = ["E501", "E741"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 18
-
-[tool.isort]
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-ensure_newline_before_comments = true
-line_length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ dev = [
     { include-group = "typing" },
     { include-group = "test" },
     { include-group = "coverage" },
-    { include-group = "docs" },
 ]
 lint = [
     "blackdoc>=0.3.9",
@@ -63,11 +62,6 @@ test = [
 ]
 coverage = [
     "pytest-cov>=7.0.0",
-]
-docs = [
-    "mkdocs>=1.6.1",
-    "mkdocs-material>=9.7.1",
-    "mkdocstrings[python]>=0.30.1",
 ]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "jax>=0.4.28",
     "svgwrite>=1.4.3",
     "typing-extensions>=4.2.0",
-    "uvicorn>=0.40.0",
+    "uvicorn>=0.39.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,3 +77,7 @@ ignore = ["E501", "E741"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 18
+
+[tool.mypy]
+python_version = "3.9"
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,25 @@ where = ["."]
 requires = ["setuptools>=77.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[dependency-groups]
+dev = [
+    { include-group = "lint" },
+    { include-group = "typing" },
+    { include-group = "test" },
+]
+lint = [
+    "blackdoc>=0.3.9",
+    "ruff>=0.14.11",
+]
+typing = [
+    "mypy>=1.19.1",
+]
+test = [
+    "pytest>=8.4.2",
+    "pytest-cov>=7.0.0",
+    "pytest-xdist>=3.8.0",
+]
+
 [tool.black]
 line-length = 120
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,3 +81,4 @@ max-complexity = 18
 [tool.mypy]
 python_version = "3.9"
 ignore_missing_imports = true
+plugins = ["pydantic.mypy"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,0 @@
-# jax must be installed previously depending on hardware
-# jax==0.4.28 is the oldest version available now (2025.12.27)
-jax>=0.4.28
-typing_extensions>=4.2.0
-svgwrite
-
-# UI
-fastapi
-uvicorn


### PR DESCRIPTION
pyproject.toml を更新します。

## 1. isort の不要な設定を削除

既存の isort の設定は Ruff のデフォルト値でカバーできるため、`[tool.isort]` を削除しました。

## 2. mypy の設定を追加

- Makefile で指定されていたオプションを pyproject.toml 内の設定に追加しました。
- Makefile の `check` コマンドでの不要なオプション引数を削除しました。
- FastAPI で利用する Pydantic のプラグインを追加しました。

## 3. uvicorn のバージョンダウン

uvicorn 0.40.0 は Python 3.10 以上が必要なため、Python 3.9 に対応している 0.39.0 にバージョンを下げました。

## 4. [dependency-groups] 導入

開発用の依存関係を [dependency-groups] で指定しました。
追加する依存関係は Makefile のコマンドからリストアップしました。
また、Makefile の`install-dev` を [dependency-groups] を参照するように変更しました。

## 5. requirements.txt 削除

プロジェクトルートの requirements.txt は不要になったため削除しました。
`pip install mahjax` で依存関係がインストールされるようになったため、`docs/ui.md` からも不要な記述を削除しました。