### PR TITLE
[API] modify terminal-related API

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,13 +1,14 @@
-# How to install
+# API
+
+## Install
 
 ```
 pip install mahjax
 ```
 
-# Usage
-We follow almost the same api as [pgx](https://github.com/sotetsuk/pgx).
-Below is the example of usage of mahjax.
+## Usage
 
+We follow almost the same API as [pgx](https://github.com/sotetsuk/pgx). Below is the example of usage of mahjax.
 
 ```py
 import jax
@@ -21,8 +22,9 @@ rng = jax.random.PRNGKey(0)
 # Initialize environment and state
 env = mahjax.make(
     "red_mahjong",
-    round_mode="single",  # "single", "east" (tonpuusen), or "half" (hanchan)
-    order_points=[30, 10, -10, -30]  # You can specify the order points by thousands.
+    round_mode="single",   # "single", "east" (tonpuusen), or "half" (hanchan)
+    next_round_style="auto",  # "auto" (default, RL) or "dummy_share" (interactive / mjai)
+    order_points=[30, 10, -10, -30],
 )
 step_fn = jax.jit(jax.vmap(env.step))
 obs_fn = jax.jit(jax.vmap(env.observe))
@@ -41,3 +43,189 @@ while not state.terminated.all():
     state = step_fn(state, action, rngs)
     reward = state.rewards  # (batch_size, 4) access to the reward.
 ```
+
+## State
+
+Both `no_red_mahjong` and `red_mahjong` share the same nested state layout. The state is an immutable JAX dataclass (`EnvState`) made of:
+
+- a small set of **top-level fields** (the standard RL handles)
+- a per-player array group (`state.players`, a `PlayerStateArrays`)
+- a round-level array group (`state.round_state`, a `RoundState`)
+
+`red_mahjong` adds a few extra fields on top of this — those are listed in [Red Mahjong](red_mahjong.md). The common fields are the same.
+
+### Top-level fields (`state`)
+
+| Field | Shape | Type | Meaning |
+| :--- | :---: | :--- | :--- |
+| `current_player` | `()` | `int8` | Player whose turn it is. The legal action mask exposed at the top level always belongs to this player. |
+| `legal_action_mask` | `(num_actions,)` | `bool` | Legal action mask for `current_player`. At terminal states this is set to all-`True` to avoid zero-division when normalizing action probabilities. |
+| `rewards` | `(4,)` | `float32` | 4-player reward vector for the **step that just ran**. Mahjong rewards are score deltas in hundreds of points (e.g. ron payments, tsumo payments, tenpai/noten settlement, illegal-action penalty). Zero in steps that produced no scoring event. |
+| `terminated` | `()` | `bool` | Game terminal. `True` once for the step that ends the game; remains `True` afterwards. After it goes `True`, subsequent `env.step` calls return the state unchanged with zero rewards. |
+| `truncated` | `()` | `bool` | Reserved for external truncation wrappers (e.g. `TimeLimit`). Mahjax does not itself produce truncated episodes. |
+| `step_count` | `()` | `int32` | Total `env.step` calls applied so far. |
+| `players` | nested | `PlayerStateArrays` | Per-player arrays — see below. |
+| `round_state` | nested | `RoundState` | Round-level arrays — see below. |
+
+### `state.players` — per-player state
+
+All entries are leading-axis-`4` arrays indexed by absolute player id (seat 0..3).
+
+| Field | Shape | Type | Meaning |
+| :--- | :---: | :--- | :--- |
+| `hand` | `(4, 34)` | `int8` | Tile-type histogram of each player's concealed hand. |
+| `legal_action_mask` | `(4, num_actions)` | `bool` | Per-player legal action mask. The 1-D `state.legal_action_mask` is `players.legal_action_mask[current_player]`. |
+| `can_win` | `(4, 34)` | `bool` | For each player and tile type, whether the player can win on that tile. |
+| `has_yaku` | `(4, 2)` | `bool` | Whether each player has a valid yaku, for RON / TSUMO respectively. |
+| `fan` | `(4, 2)` | `int32` | Fan count, for RON / TSUMO respectively. |
+| `fu` | `(4, 2)` | `int32` | Fu count, for RON / TSUMO respectively. |
+| `melds` | `(4, 4)` | `uint16` | Packed meld records (action / target / src). |
+| `meld_counts` | `(4,)` | `int8` | Number of melds claimed by each player. |
+| `river` | `(4, 24)` | `uint16` | Discard rivers; packed tile + tsumogiri flag. |
+| `discard_counts` | `(4,)` | `int8` | Number of discards in each player's river. |
+| `riichi` | `(4,)` | `bool` | Whether each player is in riichi. |
+| `riichi_declared` | `(4,)` | `bool` | Whether each player has declared riichi this turn (latch cleared on accept). |
+| `double_riichi` | `(4,)` | `bool` | Double-riichi flag per player. |
+| `ippatsu` | `(4,)` | `bool` | Ippatsu still live per player. |
+| `furiten_by_discard` | `(4,)` | `bool` | Furiten because of own discard. |
+| `furiten_by_pass` | `(4,)` | `bool` | Furiten because of passed RON. |
+| `is_hand_concealed` | `(4,)` | `bool` | Hand still closed (no open melds). |
+| `pon` | `(4, 34)` | `int32` | Bookkeeping for pon-related calls per tile type. |
+| `has_won` | `(4,)` | `bool` | Whether each player won this round (set on RON / TSUMO). |
+| `n_kan` | `(4,)` | `int8` | Number of kan declared by each player this round. |
+
+### `state.round_state` — round-level state
+
+Held common across all four players.
+
+| Field | Shape | Type | Meaning |
+| :--- | :---: | :--- | :--- |
+| `rng_key` | `(2,)` | `uint32` | JAX PRNG key used to deal the current round. |
+| `action_history` | `(3, 200)` | `int8` | Per-step action history. Row 0 acting player, row 1 action payload (discarded tile for discards, raw action id otherwise), row 2 tsumogiri flag. |
+| `round` | `()` | `int8` | Round index (`0`-based). |
+| `round_limit` | `()` | `int8` | Round limit derived from `round_mode`: `4` for `east`, `8` for `half`. |
+| `terminated_round` | `()` | `bool` | `True` on the step that ends the round (RON / TSUMO / 流局). See the round-transition section for how `auto` vs `dummy_share` expose this. |
+| `honba` | `()` | `int8` | Honba count (renchan counter). |
+| `kyotaku` | `()` | `int8` | Number of unclaimed riichi sticks on the table. |
+| `init_wind` | `(4,)` | `int8` | Initial seat winds at the start of the game. |
+| `seat_wind` | `(4,)` | `int8` | Current seat wind per player. |
+| `dealer` | `()` | `int8` | Current dealer. |
+| `order_points` | `(4,)` | `int32` | Placement bonus / uma. |
+| `score` | `(4,)` | `int32` | Per-player score, in hundreds of points. |
+| `deck` | `(136,)` | `int8` | Current round's shuffled wall (tile types). |
+| `next_deck_ix` | `()` | `int32` | Next index to draw from in `deck`. |
+| `last_deck_ix` | `()` | `int8` | End of the live wall. |
+| `last_draw` | `()` | `int8` | Most recently drawn tile type. |
+| `last_player` | `()` | `int8` | Player who took the previous action (used for discard-target resolution). |
+| `dora_indicators` | `(5,)` | `int8` | Dora indicator tile types; `-1` for unrevealed slots. |
+| `ura_dora_indicators` | `(5,)` | `int8` | Ura-dora indicators; `-1` for unrevealed slots. |
+| `is_abortive_draw_normal` | `()` | `bool` | True once the wall has been exhausted (流局). |
+| `is_haitei` | `()` | `bool` | Currently on the last live-wall tile (海底). |
+| `target` | `()` | `int8` | Tile currently being targeted by callers. |
+| `n_kan_doras` | `()` | `int8` | Number of kan dora flipped so far this round. |
+| `kan_declared` | `()` | `bool` | Kan declared this step. |
+| `can_after_kan` | `()` | `bool` | After-kan / 嶺上開花 still possible. |
+| `can_robbing_kan` | `()` | `bool` | A robbing-a-kan / 槍槓 window is open. |
+| `draw_next` | `()` | `bool` | Internal flag: the env should draw a tile next. |
+| `dummy_count` | `()` | `int8` | Counter for the DUMMY-rotation phase. Only used by `next_round_style="dummy_share"` (see below); always `0` under `auto`. |
+
+## Round Transition Style (`next_round_style`)
+
+In multi-round modes (`east` / `half`) the env can either advance to the next round **automatically inside a single `env.step`**, or expose an explicit DUMMY-action phase that lets every seat observe the round-end state before the next round begins. This is controlled by `next_round_style`:
+
+```py
+env = mahjax.make("red_mahjong", round_mode="half", next_round_style="auto")  # default
+env = mahjax.make("red_mahjong", round_mode="half", next_round_style="dummy_share")
+```
+
+| Style | Default | When to use |
+| :--- | :--- | :--- |
+| `auto` | ✅ | RL / training. One round transition = one `env.step`. |
+| `dummy_share` |  | Interactive UI, mjai-compatible replays, anything that needs per-player round-end observation. |
+
+In `single` mode the two styles are identical — there is no "next round."
+
+### How a round-end step looks in each style
+
+When the agent plays the action that ends a round (RON / TSUMO / exhaustive draw):
+
+**`auto`** — collapse the round transition into a single step:
+
+```
+   t      action      terminated_round   terminated   rewards
+   k       RON              False           False        X        ← state for round k+1's first turn,
+                                                                    but `rewards` carries the round-end reward
+```
+
+The state returned by `env.step` is already the **next round's init state** (new deck, new dealer if needed, fresh hands, `legal_action_mask` for the new dealer). `terminated` is `False` until the game itself ends; on the game-ending round it is `True` and the score is updated with rank points + kyotaku bonuses.
+
+**`dummy_share`** — make the round-end phase explicit. After the winning action, the env exposes a state with `legal_action_mask` containing only `DUMMY` for every seat. Each of the four players must then play `DUMMY`; the fourth `DUMMY` advances to the next round.
+
+```
+   t      action      terminated_round   dummy_count   rewards
+   k       RON              True              0           X
+   k+1     DUMMY            True              1           X      (player k+1)
+   k+2     DUMMY            True              2           X      (player k+2)
+   k+3     DUMMY            True              3           X      (player k+3)
+   k+4     DUMMY            False             0           0      ← next round's init state
+```
+
+This matches the "次の局へ" / "next round" button in interactive UIs and the round-end packet broadcast in mjai-style protocols. It is also the style validated against tenhou mjlogs by `mahjax_tenhou_test`.
+
+State equivalence (proved by `TestAutoDummyShareParity` in `tests/`): for the same initial state, the next-round init produced by **one `auto` step** equals the next-round init produced by **five `dummy_share` steps (RON + 4 × DUMMY)**, comparing every round-level and player-level field. The only intentional differences are `step_count` (which advances per `env.step` call) and `rewards` (preserved by `auto` on the transition step; delivered by `dummy_share` on the RON step and zeroed thereafter).
+
+### Using `auto` rewards in RL
+
+Mahjong reward is sparse: it lands on the steps that end a round (RON / TSUMO / 流局). Under `auto`, that reward vector is **carried on the same step that produces the next round's observation**. This is the simplest interface for turn-based MARL because each `env.step` corresponds to exactly one logical decision and exactly one reward delivery.
+
+Note that turn-based mahjong is not a synchronous MARL game: only `current_player` acts at each step. The reward, however, is a 4-player vector — a player whose seat is not `current_player` may still receive a non-zero reward (for example, the discarder of a winning tile). The GAE has to account for "I received reward while I was not on turn." The standard trick used by the PPO example in `examples/ppo_with_reg.py` (and by NashPG / Pgx-style turn-based RL in general) is a **per-player reward accumulator**.
+
+#### GAE for turn-based MARL with per-player reward accumulators
+
+Rollout each step records, for the agent that just acted:
+
+```py
+Transition(
+    is_new_episode,           # 1 if this step is the first step of a fresh episode
+    action,                   # what the acting player did
+    value,                    # V(s_t) for the acting player's network
+    reward,                   # 4-vector of rewards delivered at this step
+    log_prob,                 # log π(a_t | s_t)
+    observation,              # observation from current_player's perspective
+    action_mask,              # legal action mask shown to current_player
+    current_player,           # which seat acted
+)
+```
+
+Backward scan to compute advantages: for each player keep a running accumulator. When we visit a step whose `current_player == p`, that's where player `p`'s next decision happens — we settle `p`'s accumulated reward into a single per-decision delta:
+
+```py
+def gae_backward(advantage_next, value_next, reward_accum, transition):
+    p = transition.current_player                # who acted at this step
+    reward_p = reward_accum[p] + transition.reward[p]  # everything p has accumulated since last on-turn
+    delta = reward_p + gamma * value_next * (1 - transition.is_new_episode) - transition.value
+    advantage = delta + gamma * gae_lambda * (1 - transition.is_new_episode) * advantage_next
+
+    # Reset p's accumulator (consumed). Continue accumulating other players' rewards.
+    reward_accum = reward_accum.at[p].set(0.0)
+    reward_accum = reward_accum + transition.reward          # still owe other players
+    reward_accum = reward_accum.at[p].set(0.0)               # but not p again on this step
+
+    return advantage, value, reward_accum
+```
+
+Round transitions under `auto` slot into this naturally:
+
+- The RON step delivers a non-zero `reward` vector; the next observation is already the next round's init.
+- The discarder seat that paid out is *not* `current_player` on this step (the RON player is). The discarder's reward sits in its accumulator until the discarder's next on-turn step (which is now in the new round).
+- This is consistent with how mahjong logically works: the discarder learns about the loss on the same observation that opens its next turn.
+
+With `dummy_share` instead, the rewarded step (RON) is followed by four DUMMY steps with zero reward, and the next-round init shows up only at step `k+4`. RL-wise this is wasteful (one logical decision = five env steps, four of them no-op) and clutters the trajectory with "DUMMY" actions that should not appear in a policy's action distribution. That is why `auto` is the default — it gives the same state equivalence as `dummy_share` but exposes a clean one-step-per-decision API.
+
+### When to choose `dummy_share`
+
+- Driving an interactive UI (the user clicks "next round" after seeing the round-end summary).
+- Round-end packet replay against external logs (e.g. mjai / mjlog) where every seat is expected to observe the round-end state.
+- Tests / harnesses that need to inspect the in-between round-end state explicitly (e.g. score breakdown, win declaration UI). `mahjax_tenhou_test` uses this style.
+
+For everything else, use `auto`.

--- a/docs/api.md
+++ b/docs/api.md
@@ -170,7 +170,7 @@ The state returned by `env.step` is already the **next round's init state** (new
    k+4     DUMMY            False             0           0      ← next round's init state
 ```
 
-This matches the "次の局へ" / "next round" button in interactive UIs and the round-end packet broadcast in mjai-style protocols. It is also the style validated against tenhou mjlogs by `mahjax_tenhou_test`.
+This matches the "次の局へ" / "next round" button in interactive UIs.
 
 State equivalence (proved by `TestAutoDummyShareParity` in `tests/`): for the same initial state, the next-round init produced by **one `auto` step** equals the next-round init produced by **five `dummy_share` steps (RON + 4 × DUMMY)**, comparing every round-level and player-level field. The only intentional differences are `step_count` (which advances per `env.step` call) and `rewards` (preserved by `auto` on the transition step; delivered by `dummy_share` on the RON step and zeroed thereafter).
 
@@ -226,6 +226,5 @@ With `dummy_share` instead, the rewarded step (RON) is followed by four DUMMY st
 
 - Driving an interactive UI (the user clicks "next round" after seeing the round-end summary).
 - Round-end packet replay against external logs (e.g. mjai / mjlog) where every seat is expected to observe the round-end state.
-- Tests / harnesses that need to inspect the in-between round-end state explicitly (e.g. score breakdown, win declaration UI). `mahjax_tenhou_test` uses this style.
 
 For everything else, use `auto`.

--- a/docs/no_red_mahjong.md
+++ b/docs/no_red_mahjong.md
@@ -18,8 +18,7 @@ env = NoRedMahjong(round_mode="half", observe_type="dict")
 
 ## Description
 
-`no_red_mahjong` is a fast 4-player riichi mahjong environment without red fives.
-It is the lightweight environment used by the current offline RL and PPO examples.
+`no_red_mahjong` is a fast 4-player riichi mahjong environment without red fives. It is the lightweight environment used by the current offline RL and PPO examples.
 
 Compared with `red_mahjong`, this environment intentionally omits some rules in order to keep the implementation simpler and faster.
 
@@ -32,19 +31,19 @@ The environment is a simplified Japanese riichi mahjong variant without red five
 - No pao
 - No double ron
 
-This environment exists primarily for speed and for simpler RL experiments.
-It is covered by hand-written tests, and we do not expect major rule-breaking bugs, but some corner cases may still remain.
-We expect this to improve over time.
+This environment exists primarily for speed and for simpler RL experiments. It is covered by hand-written tests, and we do not expect major rule-breaking bugs, but some corner cases may still remain. We expect this to improve over time.
 
 For general riichi mahjong rules, see the [European Mahjong Association rulebook](https://mahjong-europe.org/portal/images/docs/Riichi-rules-2025-EN.pdf).
 
-## State Representation
+## State
 
-`no_red_mahjong` currently uses the older flat state layout.
-Mahjong-specific fields live directly on the state object, such as `_hand`, `_river`, `_melds`, `_score`, and `_action_history`.
+`no_red_mahjong` uses the same nested state layout as `red_mahjong`:
 
-This differs from `red_mahjong`, which uses a newer nested representation with `players` and `round_state`.
-These two environments therefore do **not** currently share the same internal state representation, though we may unify them in the future.
+- top-level RL handles (`current_player`, `terminated`, `rewards`, …)
+- `state.players` — per-player arrays (`PlayerStateArrays`)
+- `state.round_state` — round-level arrays (`RoundState`)
+
+The full field list and round-transition style (`auto` / `dummy_share`) are documented once in [API](api.md). `no_red_mahjong` uses **exactly** the common field set there; it does not add any extra fields on top.
 
 ## Specs
 
@@ -54,14 +53,30 @@ These two environments therefore do **not** currently share the same internal st
 | Number of players | `4` |
 | Number of actions | `79` |
 | Observation types | `dict`, `2D` |
-| Dict action history shape | `(3, 200)` |
 | Reward shape | `(4,)` |
 | Reward semantics | score deltas in hundreds of points |
 
+## Action
+
+The action space (79 actions):
+
+| Range | Meaning |
+| :--- | :--- |
+| `0-33` | Discard a tile type |
+| `34-67` | Closed kan / added kan |
+| `68` | `TSUMOGIRI` |
+| `69` | `RIICHI` |
+| `70` | `TSUMO` |
+| `71` | `RON` |
+| `72` | `PON` |
+| `73` | `OPEN_KAN` |
+| `74-76` | `CHI_L`, `CHI_M`, `CHI_R` |
+| `77` | `PASS` |
+| `78` | `DUMMY` (only legal under `next_round_style="dummy_share"`) |
+
 ## Dict Observation
 
-The current training examples use the `dict` observation.
-It is the most stable observation format in this repository right now, but it may still change in future releases.
+The current training examples use the `dict` observation. It is the most stable observation format in this repository right now, but it may still change in future releases.
 
 The returned dictionary contains:
 
@@ -69,7 +84,7 @@ The returned dictionary contains:
 | :--- | :---: | :--- |
 | `hand` | `(14,)` | Current player's hand as sorted tile types in `[0, 33]`; unused slots are `-1`. |
 | `last_draw` | `()` | Last drawn tile in `[0, 33]`; `-1` means there is no drawn tile to expose. |
-| `action_history` | `(3, 200)` | Action history in the same style as `red_mahjong`. |
+| `action_history` | `(3, 200)` | Action history. |
 | `shanten_count` | `()` | Current player's shanten number. |
 | `furiten` | `()` | Whether the current player is in furiten. |
 | `scores` | `(4,)` | Scores ordered from the current player's perspective. |
@@ -98,26 +113,7 @@ For `no_red_mahjong`, discard tiles are in `[0, 33]` and raw action ids are in `
 
 ## 2D Observation
 
-`observe_type="2D"` exists, but its design is not yet fixed.
-You can use it for experiments, but we do not recommend treating it as a stable interface yet.
-
-## Action
-
-The action space is:
-
-| Range | Meaning |
-| :--- | :--- |
-| `0-33` | Discard a tile type |
-| `34-67` | Closed kan / added kan |
-| `68` | `TSUMOGIRI` |
-| `69` | `RIICHI` |
-| `70` | `TSUMO` |
-| `71` | `RON` |
-| `72` | `PON` |
-| `73` | `OPEN_KAN` |
-| `74-76` | `CHI_L`, `CHI_M`, `CHI_R` |
-| `77` | `PASS` |
-| `78` | `DUMMY` |
+`observe_type="2D"` exists, but its design is not yet fixed. You can use it for experiments, but we do not recommend treating it as a stable interface yet.
 
 ## Rewards
 
@@ -129,8 +125,12 @@ Examples:
 - exhaustive draw can produce tenpai / noten payments
 - illegal actions end the game immediately with the standard illegal-action penalty
 
+For how to consume these rewards in turn-based MARL training (per-player reward accumulator + GAE), see the [API → Using `auto` rewards in RL](api.md#using-auto-rewards-in-rl) section.
+
 ## Termination
 
 - `round_mode="single"` terminates after the first round ends.
 - `round_mode="east"` runs East-only progression with `round_limit=4`.
 - `round_mode="half"` runs East-South progression with `round_limit=8`.
+
+In multi-round modes, the next-round transition behavior is controlled by `next_round_style` (see [API](api.md#round-transition-style-next_round_style)).

--- a/docs/red_mahjong.md
+++ b/docs/red_mahjong.md
@@ -23,16 +23,13 @@ env = RedMahjong(
 
 ## Description
 
-`red_mahjong` is the full red-five riichi mahjong environment in MahJax.
-It is the environment intended to track modern online riichi mahjong more closely.
+`red_mahjong` is the full red-five riichi mahjong environment in MahJax. It is the environment intended to track modern online riichi mahjong more closely.
 
-This implementation is designed to follow **Tenhou** as closely as practical, and we validate it against downloaded Tenhou game logs.
-We do not describe the log-test details here, but this is the main correctness target for the environment.
+This implementation is designed to follow **Tenhou** as closely as practical, and we validate it against downloaded Tenhou game logs. We do not describe the log-test details here, but this is the main correctness target for the environment.
 
 ## Rules
 
-The environment implements 4-player riichi mahjong with red fives.
-By default, the rule configuration enables:
+The environment implements 4-player riichi mahjong with red fives. By default, the rule configuration enables:
 
 - red fives
 - double ron
@@ -43,18 +40,48 @@ The detailed external rule reference is:
 
 - [Tenhou rules (official English page)](https://tenhou.net/0/mj/mjlog/en/mjlog-en-rules.html)
 
-The rule behavior is controlled through `GameConfig`, so advanced users can change settings such as red-fives usage, double ron, pao, and special abortive draws.
+### `GameConfig`
 
-## State Representation
+The rule behavior is controlled through `GameConfig`. Advanced users can change settings such as red-fives usage, double ron, pao, and special abortive draws.
 
-`red_mahjong` uses the newer nested state layout.
-Mahjong-specific fields are grouped into:
+| Field | Default | Meaning |
+| :--- | :--- | :--- |
+| `use_red_fives` | `True` | Enable red 5m / 5p / 5s tiles. |
+| `allow_double_ron` | `True` | Allow two players to win simultaneously on the same discard. |
+| `enable_special_abortive_draw` | `True` | Enable 九種九牌 / 四風連打 / 四家立直 / 三家和 / 四開槓. |
+| `enable_pao` | `True` | Enable 包 (responsibility payment) for 大三元 / 大四喜. |
+| `allow_open_tanyao` | `True` | Allow tanyao with open melds (`喰いタン`). |
+| `allow_kuikae` | `False` | Allow swap-calling (`喰い替え`). |
+| `seed_wall_from_key` | `True` | Use the env's PRNG key to shuffle the wall. |
+| `starting_points` | `250` | Starting score (hundreds of points). |
+| `target_points` | `300` | Target score for ending sudden death overtime. |
+| `honba_bonus` | `300` | Honba bonus payment. |
+| `riichi_bet` | `1000` | Riichi stick value. |
 
-- `state.players`
-- `state.round_state`
+## State
 
-This differs from `no_red_mahjong`, which still uses the older flat underscore-prefixed fields.
-The two environments therefore do **not** currently share the same internal state representation, though we may align them in the future.
+`red_mahjong` uses the same nested state layout as `no_red_mahjong`:
+
+- top-level RL handles (`current_player`, `terminated`, `rewards`, …)
+- `state.players` — per-player arrays (`PlayerStateArrays`)
+- `state.round_state` — round-level arrays (`RoundState`)
+
+The shared field list and the round-transition style (`auto` / `dummy_share`) are documented once in [API](api.md). `red_mahjong` adds the following **red-five-aware fields** on top of the shared `PlayerStateArrays`:
+
+| Field | Shape | Type | Meaning |
+| :--- | :---: | :--- | :--- |
+| `hand_with_red` | `(4, 37)` | `int8` | Hand histogram in the 37-tile-type space (34 tile types + 3 red fives). |
+| `hand_ids` | `(4, 14)` | `int16` | Individual tile ids in the hand (each id in `[0, 135]`); unused slots are sentinel. |
+| `hand_counts` | `(4,)` | `int8` | Number of valid tiles in `hand_ids`. |
+| `drawn_tile` | `(4,)` | `int16` | Most recent drawn tile id per player; sentinel if none. |
+| `meld_tiles` | `(4, 4, 4)` | `int16` | Tile ids that make up each meld. |
+| `meld_info` | `(4, 4, 3)` | `int8` | Auxiliary info per meld (target / src / action). |
+| `discards` | `(4, 24)` | `int16` | Individual discarded tile ids per player. |
+| `discard_info` | `(4, 24, 4)` | `int8` | Auxiliary info per discard (tsumogiri flag, etc.). |
+| `riichi_step` | `(4,)` | `int8` | Step at which each player declared riichi (for ippatsu tracking). |
+| `has_nagashi_mangan` | `(4,)` | `bool` | Whether each player is still eligible for 流し満貫. |
+
+The shared `hand` array (tile-type histogram in `[0, 33]` space) is also still kept for backward compatibility with code paths that do not need red-five resolution.
 
 ## Specs
 
@@ -64,14 +91,32 @@ The two environments therefore do **not** currently share the same internal stat
 | Number of players | `4` |
 | Number of actions | `87` |
 | Observation types | `dict`, `2D` |
-| Dict action history shape | `(3, 200)` |
 | Reward shape | `(4,)` |
 | Reward semantics | score deltas in hundreds of points |
 
+## Action
+
+The action space (87 actions):
+
+| Range | Meaning |
+| :--- | :--- |
+| `0-36` | Discard a tile, including red-five tile ids |
+| `37-70` | Closed kan / added kan |
+| `71` | `TSUMOGIRI` |
+| `72` | `RIICHI` |
+| `73` | `TSUMO` |
+| `74` | `RON` |
+| `75` | `PON` |
+| `76` | `PON_RED` |
+| `77` | `OPEN_KAN` |
+| `78-83` | Chi variants including red-five-aware actions |
+| `84` | `PASS` |
+| `85` | `KYUUSHU` |
+| `86` | `DUMMY` (only legal under `next_round_style="dummy_share"`) |
+
 ## Dict Observation
 
-The current training-oriented observation is `dict`.
-It is the format we recommend if you need a structured observation today, though we still reserve the right to revise it in future releases.
+The current training-oriented observation is `dict`. It is the format we recommend if you need a structured observation today, though we still reserve the right to revise it in future releases.
 
 The returned dictionary contains:
 
@@ -108,28 +153,7 @@ For `red_mahjong`, discard tiles are in `[0, 36]` because red fives have dedicat
 
 ## 2D Observation
 
-`observe_type="2D"` is available, but we do not consider its design finalized yet.
-If you need a representation whose semantics are less likely to move, prefer `dict`.
-
-## Action
-
-The action space is:
-
-| Range | Meaning |
-| :--- | :--- |
-| `0-36` | Discard a tile, including red-five tile ids |
-| `37-70` | Closed kan / added kan |
-| `71` | `TSUMOGIRI` |
-| `72` | `RIICHI` |
-| `73` | `TSUMO` |
-| `74` | `RON` |
-| `75` | `PON` |
-| `76` | `PON_RED` |
-| `77` | `OPEN_KAN` |
-| `78-83` | Chi variants including red-five-aware actions |
-| `84` | `PASS` |
-| `85` | `KYUUSHU` |
-| `86` | `DUMMY` |
+`observe_type="2D"` is available, but we do not consider its design finalized yet. If you need a representation whose semantics are less likely to move, prefer `dict`.
 
 ## Rewards
 
@@ -143,8 +167,14 @@ This includes:
 - pao when enabled in `GameConfig`
 - illegal-action termination penalties
 
+For how to consume these rewards in turn-based MARL training (per-player reward accumulator + GAE), see the [API → Using `auto` rewards in RL](api.md#using-auto-rewards-in-rl) section.
+
 ## Termination
 
 - `round_mode="single"` terminates after the first round ends.
 - `round_mode="east"` runs East-only progression with `round_limit=4`.
 - `round_mode="half"` runs East-South progression with `round_limit=8`.
+
+In multi-round modes, the next-round transition behavior is controlled by `next_round_style` (see [API](api.md#round-transition-style-next_round_style)).
+
+`red_mahjong` is the env used by `mahjax_tenhou_test`, which validates round trajectories against real tenhou mjlogs using `next_round_style="dummy_share"`. The state-level equivalence between `auto` and `dummy_share` at round boundaries is asserted by the parity tests in `tests/red_mahjong/test_env.py`, so the same correctness target also covers `auto` mode end-to-end.

--- a/mahjax/no_red_mahjong/env.py
+++ b/mahjax/no_red_mahjong/env.py
@@ -210,16 +210,22 @@ class NoRedMahjong(Env):
             -10,
             -30,
         ],  # No oka, 10-30, SAIKOUISEN rule https://saikouisen.com/about/rules/
+        next_round_style: Literal["auto", "dummy_share"] = "auto",
     ):
         if round_mode not in ("single", "east", "half"):
             raise ValueError(f"round_mode must be one of ('single', 'east', 'half'), got: {round_mode}")
         if observe_type == "2D":
             raise ValueError(f"observe type 2D is not developed yet")
+        if next_round_style not in ("auto", "dummy_share"):
+            raise ValueError(
+                f"next_round_style must be one of ('auto', 'dummy_share'), got: {next_round_style}"
+            )
         self.round_mode = round_mode
         self.one_round = round_mode == "single"
         self.round_limit = jnp.int8(4 if round_mode == "east" else 8)
         self.observe_func = _observe_dict if observe_type == "dict" else _observe_2D
         self.order_points = order_points
+        self.next_round_style = next_round_style
 
     def init(self, key: PRNGKey) -> State:
         """Return the initial state. Note that no internal state of
@@ -256,7 +262,8 @@ class NoRedMahjong(Env):
 
         # If the state is already terminated or truncated, environment does not take usual step,
         # but return the same state with zero-rewards for all players
-        stepped_state = _replace_state(_step(state, action), step_count=state.step_count + 1)
+        step_fn = _step_auto if self.next_round_style == "auto" else _step_dummy_share
+        stepped_state = _replace_state(step_fn(state, action), step_count=state.step_count + 1)
         state = jax.lax.cond(
             (state.terminated | state.truncated),
             lambda: _replace_state(state, rewards=jnp.zeros_like(state.rewards)),  # type: ignore
@@ -267,6 +274,17 @@ class NoRedMahjong(Env):
             lambda: _replace_state(state, terminated=TRUE),
             lambda: state,
         )
+        # ``auto`` next_round_style: when a round ends mid-game (not single mode, not
+        # yet game-terminated), advance straight to the next round init state in this
+        # same step instead of requiring four DUMMY rotations. If the round-end
+        # coincides with the game-end, terminate=True and update the final score
+        # with rank points + kyotaku.
+        if self.next_round_style == "auto":
+            state = jax.lax.cond(
+                state.round_state.terminated_round & ~state.terminated & ~jnp.bool_(self.one_round),
+                lambda: _advance_to_next_round_auto(state),
+                lambda: state,
+            )
         # Taking illegal action leads to immediate game terminal with negative reward
         state = jax.lax.cond(
             is_illegal,
@@ -501,34 +519,53 @@ def _is_first_turn(next_deck_ix: Array) -> Array:
     return next_deck_ix >= FIRST_DRAW_IDX - 4
 
 
-def _step(state: State, action: Array) -> State:
-    """
-    Branch the process according to the action
-    The type of action is referred to mahjong/_action.py
-    """
+def _append_action_history(state: State, action: Array) -> Array:
     action_i8 = jnp.int8(action)
-    # add current player
     action_history = state.round_state.action_history.at[0, state.step_count].set(
         state.current_player
     )
-    # For discards, row 1 stores the discarded tile and row 2 stores the
-    # tsumogiri flag. Non-discard actions keep the raw action id and use -1.
     is_tsumogiri = action_i8 == Action.TSUMOGIRI
     is_discard = ((0 <= action_i8) & (action_i8 < Tile.NUM_TILE_TYPE)) | is_tsumogiri
-    recorded_action = jnp.where(is_tsumogiri, state.round_state.last_draw, action_i8).astype(
-        jnp.int8
-    )
+    recorded_action = jnp.where(
+        is_tsumogiri, state.round_state.last_draw, action_i8
+    ).astype(jnp.int8)
     tsumogiri_flag = jnp.where(
         is_discard,
         is_tsumogiri.astype(jnp.int8),
         jnp.int8(-1),
     )
     action_history = action_history.at[1, state.step_count].set(recorded_action)
-    action_history = action_history.at[2, state.step_count].set(tsumogiri_flag)
-    state = _replace_state(state,   # type:ignore
-        action_history=action_history
+    return action_history.at[2, state.step_count].set(tsumogiri_flag)
+
+
+def _finalize_step_state(state: State) -> State:
+    state = jax.lax.cond(
+        state.round_state.draw_next & ~state.round_state.is_abortive_draw_normal,
+        lambda: _draw(state),
+        lambda: state,
     )
-    # execute actions
+    state = jax.lax.cond(
+        state.round_state.kan_declared
+        & ~state.round_state.is_abortive_draw_normal
+        & ~state.players.legal_action_mask[:, Action.RON].any(),
+        lambda: _draw_after_kan(state),
+        lambda: state,
+    )
+    state = jax.lax.cond(
+        state.round_state.is_abortive_draw_normal
+        & (state.round_state.dummy_count == 0)
+        & ~state.terminated,
+        lambda: _abortive_draw_normal(state),
+        lambda: state,
+    )
+    state = _replace_state(state,  # type:ignore
+        legal_action_mask=state.players.legal_action_mask[state.current_player]
+    )
+    shanten_val = Shanten.number(state.players.hand[state.current_player]).astype(jnp.int8)
+    return _replace_state(state, shanten_current_player=shanten_val)  # type:ignore
+
+
+def _dispatch_action_dummy_share(state: State, action: Array) -> State:
     discard_state = _discard(state, action)
     kan_state = _kan(state, action)
     riichi_state = _riichi(state)
@@ -539,7 +576,7 @@ def _step(state: State, action: Array) -> State:
     pass_state = _pass(state)
     next_round_state = _next_round(state)
     fn_idx = ACTION_FUN_MAP[action]
-    state = jax.lax.switch(
+    return jax.lax.switch(
         fn_idx,
         [
             lambda: discard_state,
@@ -553,33 +590,68 @@ def _step(state: State, action: Array) -> State:
             lambda: next_round_state,
         ],
     )
-    state = jax.lax.cond(
-        state.round_state.draw_next & ~state.round_state.is_abortive_draw_normal,
-        lambda: _draw(state),
-        lambda: state,
-    )  # If the player draws a tile, call _draw.
-    state = jax.lax.cond(
-        state.round_state.kan_declared
-        & ~state.round_state.is_abortive_draw_normal
-        & ~state.players.legal_action_mask[
-            :, Action.RON
-        ].any(),  # If the player cannot declare a RobbingKan, call _draw_after_kan.
-        lambda: _draw_after_kan(state),
-        lambda: state,
-    )  # If the player declares a Kan, call _draw_after_kan.
-    state = jax.lax.cond(
-        state.round_state.is_abortive_draw_normal & (state.round_state.dummy_count == 0) & ~state.terminated,
-        lambda: _abortive_draw_normal(state),
-        lambda: state,
-    )  # If the game is ended (abortive_draw_normal (流局)), call _abortive_draw_normal.
-    state = _replace_state(state,   # type:ignore
-        legal_action_mask=state.players.legal_action_mask[state.current_player]
-    )  # Set the legal action mask for the current player.
-    shanten_val = Shanten.number(state.players.hand[state.current_player]).astype(jnp.int8)
-    state = _replace_state(state,   # type:ignore
-        shanten_current_player=shanten_val
+
+
+def _dispatch_action_auto(state: State, action: Array) -> State:
+    """Dispatch table for ``auto`` next_round_style. Drops the ``_next_round``
+    (dummy rotation) computation — its slot is a no-op since ``DUMMY`` is
+    never a legal action under ``auto`` (any erroneous DUMMY is caught by
+    ``env.step``'s ``is_illegal`` check).
+    """
+    discard_state = _discard(state, action)
+    kan_state = _kan(state, action)
+    riichi_state = _riichi(state)
+    ron_state = _ron(state)
+    tsumo_state = _tsumo(state)
+    pon_state = _pon(state, action)
+    chi_state = _chi(state, action)
+    pass_state = _pass(state)
+    fn_idx = ACTION_FUN_MAP[action]
+    return jax.lax.switch(
+        fn_idx,
+        [
+            lambda: discard_state,
+            lambda: kan_state,
+            lambda: riichi_state,
+            lambda: ron_state,
+            lambda: tsumo_state,
+            lambda: pon_state,
+            lambda: chi_state,
+            lambda: pass_state,
+            lambda: state,  # DUMMY: no-op; illegal under ``auto``.
+        ],
     )
-    return state
+
+
+def _step_dummy_share(state: State, action: Array) -> State:
+    """Step used by ``next_round_style='dummy_share'``.
+
+    Dispatch table includes the dummy-rotation ``_next_round`` branch (selected
+    when ``action == DUMMY``). Used by the UI and by tests that exercise the
+    four-DUMMY share phase.
+    """
+    action_history = _append_action_history(state, action)
+    state = _replace_state(state, action_history=action_history)  # type:ignore
+    state = _dispatch_action_dummy_share(state, action)
+    return _finalize_step_state(state)
+
+
+def _step_auto(state: State, action: Array) -> State:
+    """Step used by ``next_round_style='auto'`` (RL default).
+
+    Skips the dummy-rotation ``_next_round`` branch — round transitions are
+    handled by the auto-advance in ``NoRedMahjong.step`` so each round ends in
+    a single env.step call.
+    """
+    action_history = _append_action_history(state, action)
+    state = _replace_state(state, action_history=action_history)  # type:ignore
+    state = _dispatch_action_auto(state, action)
+    return _finalize_step_state(state)
+
+
+# Back-compat alias for tests that import ``_step`` directly. They exercise
+# the dummy-rotation flow, which is exactly ``_step_dummy_share``.
+_step = _step_dummy_share
 
 
 def _draw(state: State) -> State:
@@ -1680,6 +1752,87 @@ def _next_round(state: State) -> State:
         dc == jnp.int8(3),
         lambda: final_start_state,
         lambda: rotate_state,  # Early return here
+    )
+
+
+def _advance_to_next_round_auto(state: State) -> State:
+    """``auto`` next_round_style: round transition without DUMMY sharing.
+
+    Called when ``terminated_round`` becomes True (RON / TSUMO / 流局) and
+    ``round_mode != "single"``. Branches into either:
+    - game end: ``terminated=True`` with final score = score + rank_points + kyotaku bonus
+    - next round: a fresh next-round init state (new deck, new dealer if needed),
+      preserving ``rewards`` from the round-end step and incrementing/keeping
+      ``step_count`` from the caller.
+    """
+    hora = state.players.has_won  # (4,)
+    is_tempai = state.players.can_win.any(axis=-1)  # (4,)
+    dealer = state.round_state.dealer
+
+    # Final score = score + rank_points + kyotaku bonus on top
+    order = jnp.argsort(-state.round_state.score)
+    rank_points = (
+        jnp.zeros_like(state.round_state.score).at[order].set(state.round_state.order_points)
+    )
+    score_with_rank = state.round_state.score + rank_points
+    top_after_rank = jnp.argmax(score_with_rank)
+    final_score = score_with_rank.at[top_after_rank].add(10 * state.round_state.kyotaku)
+
+    # Round-end / game-end conditions (matches _rotate_once + _finalize_and_start_next)
+    is_eight_consecutive_deals = state.round_state.honba >= 8
+    has_other_than_dealer_won = hora.any() & ~hora[dealer]
+    will_dealer_continue = jnp.logical_or(
+        is_tempai[dealer] & ~has_other_than_dealer_won, hora[dealer]
+    ) & ~is_eight_consecutive_deals
+
+    top_pre_rank = jnp.argmax(state.round_state.score)
+    is_final_round = state.round_state.round == state.round_state.round_limit
+    has_dealer_end = jnp.logical_not(will_dealer_continue)
+    is_dealer_top = jnp.arange(4)[top_pre_rank] == state.round_state.dealer
+    has_minus_score = (state.round_state.score < 0).any()
+    _is_game_end = (
+        (is_final_round & has_dealer_end)
+        | has_minus_score
+        | (is_final_round & is_dealer_top)
+    )
+
+    # Next round details
+    next_round = jnp.where(will_dealer_continue, state.round_state.round, state.round_state.round + 1)
+    has_winner = hora.any()
+    next_honba = jnp.where(
+        ~has_winner | will_dealer_continue, state.round_state.honba + 1, 0
+    )
+    next_dealer = jnp.where(will_dealer_continue, dealer, (dealer + 1) % 4)
+
+    rng, subkey = jax.random.split(state.round_state.rng_key)
+    base_next = _make_state(
+        rng_key=subkey,
+        current_player=next_dealer,
+        dealer=next_dealer,
+        seat_wind=_calc_wind(next_dealer),
+        round=next_round,
+        round_limit=state.round_state.round_limit,
+        order_points=state.round_state.order_points,
+        honba=next_honba,
+        kyotaku=state.round_state.kyotaku,
+        score=state.round_state.score,
+    )
+    next_round_state = _init_for_next_round(subkey, base_next)
+    next_round_state = _replace_state(next_round_state,
+        current_player=jnp.int8(next_round_state.round_state.dealer),
+        rewards=state.rewards,
+        step_count=state.step_count,
+    )
+
+    terminated_state = _replace_state(state,
+        score=jnp.int32(final_score),
+        terminated=TRUE,
+    )
+
+    return jax.lax.cond(
+        _is_game_end,
+        lambda: terminated_state,
+        lambda: next_round_state,
     )
 
 

--- a/mahjax/red_mahjong/env.py
+++ b/mahjax/red_mahjong/env.py
@@ -264,17 +264,23 @@ class RedMahjong(Env):
             -30,
         ],  # No oka, 10-30, SAIKOUISEN rule https://saikouisen.com/about/rules/
         game_config: Optional[GameConfig] = None,
+        next_round_style: Literal["auto", "dummy_share"] = "auto",
     ):
         if round_mode not in ("single", "east", "half"):
             raise ValueError(f"round_mode must be one of ('single', 'east', 'half'), got: {round_mode}")
         if observe_type == "2D":
             raise ValueError(f"observe type 2D is not developed yet")
+        if next_round_style not in ("auto", "dummy_share"):
+            raise ValueError(
+                f"next_round_style must be one of ('auto', 'dummy_share'), got: {next_round_style}"
+            )
         self.round_mode = round_mode
         self.one_round = round_mode == "single"
         self.round_limit = jnp.int8(4 if round_mode == "east" else 8)
         self.observe_func = _observe_dict if observe_type == "dict" else _observe_2D
         self.order_points = order_points
         self.game_config = _resolve_game_config(game_config)
+        self.next_round_style = next_round_style
 
     def init(self, key: PRNGKey) -> State:
         """Return the initial state. Note that no internal state of
@@ -308,8 +314,11 @@ class RedMahjong(Env):
             order_points=jnp.array(self.order_points, dtype=jnp.int32),
         )
 
+        step_fn = (
+            _step_auto if self.next_round_style == "auto" else _step_dummy_share
+        )
         stepped_state = _replace_state(
-            _step(state, action, self.game_config),
+            step_fn(state, action, self.game_config),
             step_count=state.step_count + 1,
         )
         state = jax.lax.cond(
@@ -322,6 +331,13 @@ class RedMahjong(Env):
             lambda: _replace_state(state, terminated=TRUE),
             lambda: state,
         )
+        # ``auto`` next_round_style: see the comment in no_red_mahjong/env.py.
+        if self.next_round_style == "auto":
+            state = jax.lax.cond(
+                state.round_state.terminated_round & ~state.terminated & ~jnp.bool_(self.one_round),
+                lambda: _advance_to_next_round_auto(state, self.game_config),
+                lambda: state,
+            )
         state = jax.lax.cond(
             is_illegal,
             lambda: self._step_with_illegal_action(state, current_player),
@@ -549,20 +565,46 @@ def _append_action_history(state: State, action: Array) -> Array:
     return action_history.at[2, state.step_count].set(history_tsumogiri)
 
 
-def _step(state: State, action: Array, game_config: Optional[GameConfig] = None) -> State:
-    """
-    Branch the process according to the action
-    The type of action is referred to mahjong/_action.py
+def _step_dummy_share(
+    state: State, action: Array, game_config: Optional[GameConfig] = None
+) -> State:
+    """Step used by ``next_round_style='dummy_share'``.
+
+    Dispatch table includes the dummy-rotation ``_next_round`` branch (selected
+    when ``action == DUMMY``) so that callers can drive the four-DUMMY share
+    phase explicitly. Heavier than ``_step_auto`` because both
+    ``_special_next_round`` and ``_next_round`` are pre-computed every step.
     """
     action_history = _append_action_history(state, action)
-    state = _replace_state(state,   # type:ignore
-        action_history=action_history
-    )
-    state = _dispatch_step_eager(state, action, game_config)
+    state = _replace_state(state, action_history=action_history)  # type:ignore
+    state = _dispatch_action_dummy_share(state, action, game_config)
     return _finalize_step_state(state, game_config, update_shanten=TRUE)
 
 
-def _dispatch_step_eager(state: State, action: Array, game_config: Optional[GameConfig] = None) -> State:
+def _step_auto(
+    state: State, action: Array, game_config: Optional[GameConfig] = None
+) -> State:
+    """Step used by ``next_round_style='auto'`` (RL default).
+
+    Skips the dummy-rotation ``_next_round`` branch entirely — under ``auto``
+    the auto-advance in ``RedMahjong.step`` is responsible for round
+    transitions, and ``DUMMY`` is never a legal action. The dispatch table
+    still keeps the ``_special_next_round`` branch for ``KYUUSHU``.
+    """
+    action_history = _append_action_history(state, action)
+    state = _replace_state(state, action_history=action_history)  # type:ignore
+    state = _dispatch_action_auto(state, action, game_config)
+    return _finalize_step_state(state, game_config, update_shanten=TRUE)
+
+
+# Back-compat alias for internal tests that import ``_step`` directly. They
+# exercise the dummy-rotation flow, which is exactly ``_step_dummy_share``.
+_step = _step_dummy_share
+
+
+def _dispatch_action_dummy_share(
+    state: State, action: Array, game_config: Optional[GameConfig] = None
+) -> State:
     discard_state = _discard(state, action, game_config)
     kan_state = _kan(state, action, game_config)
     riichi_state = _riichi(state)
@@ -603,7 +645,56 @@ def _dispatch_step_eager(state: State, action: Array, game_config: Optional[Game
     )
 
 
-def _dispatch_step_lazy(state: State, action: Array, game_config: Optional[GameConfig] = None) -> State:
+def _dispatch_action_auto(
+    state: State, action: Array, game_config: Optional[GameConfig] = None
+) -> State:
+    """Dispatch table for ``auto`` next_round_style. Drops the ``_next_round``
+    (dummy rotation) computation — its slot is a no-op since ``DUMMY`` is
+    never a legal action under ``auto`` (any erroneous DUMMY is caught by
+    ``env.step``'s ``is_illegal`` check).
+    """
+    discard_state = _discard(state, action, game_config)
+    kan_state = _kan(state, action, game_config)
+    riichi_state = _riichi(state)
+    ron_state = _ron(state, game_config)
+    tsumo_state = _tsumo(state, game_config)
+    pon_state = _pon(state, action)
+    chi_state = _chi(state, action)
+    pass_state = _pass(state, game_config)
+    _, next_round_rng = jax.random.split(state.round_state.rng_key)
+    prepared_next_round = _prepare_next_round_assets(next_round_rng)
+    special_next_round_state = _special_next_round(
+        state,
+        game_config,
+        next_round_rng=next_round_rng,
+        prepared_next_round=prepared_next_round,
+    )
+    fn_idx = ACTION_FUN_MAP[action]
+    return jax.lax.switch(
+        fn_idx,
+        [
+            lambda: discard_state,
+            lambda: kan_state,
+            lambda: riichi_state,
+            lambda: ron_state,
+            lambda: tsumo_state,
+            lambda: pon_state,
+            lambda: chi_state,
+            lambda: pass_state,
+            lambda: special_next_round_state,
+            lambda: state,  # DUMMY: no-op; illegal under ``auto``, env.step catches it.
+        ],
+    )
+
+
+def _dispatch_action_lazy(
+    state: State, action: Array, game_config: Optional[GameConfig] = None
+) -> State:
+    """Lazy dispatcher used by :func:`verify_step` only. Avoids the eager
+    pre-computation of every branch — branches are built as ``lambda s: ...``
+    so ``jax.lax.switch`` only traces the selected branch. Slower compile but
+    smaller working set; reserved for replay verification.
+    """
     fn_idx = ACTION_FUN_MAP[action]
     return jax.lax.switch(
         fn_idx,
@@ -621,6 +712,41 @@ def _dispatch_step_lazy(state: State, action: Array, game_config: Optional[GameC
         ],
         state,
     )
+
+
+def _step_verify_lazy(
+    state: State, action: Array, game_config: Optional[GameConfig] = None
+) -> State:
+    action_history = _append_action_history(state, action)
+    state = _replace_state(state, action_history=action_history)
+    state = _dispatch_action_lazy(state, action, game_config)
+    return _finalize_step_state(state, game_config, update_shanten=FALSE)
+
+
+def verify_step(
+    state: State,
+    action: Array,
+    game_config: Optional[GameConfig] = None,
+) -> tuple[State, Array]:
+    """Step variant for replay verification.
+
+    Returns ``(state_after, is_illegal)``. Unlike :class:`RedMahjong`'s public
+    ``step``, this does **not** apply the illegal-action penalty: when ``action``
+    is illegal, the input state is returned unchanged together with
+    ``is_illegal=True``. Used by ``mahjax_tenhou_test`` to compare env behavior
+    against tenhou mjlogs without triggering the env's penalty path.
+    """
+    is_illegal = ~state.legal_action_mask[action]
+    stepped_state = _replace_state(
+        _step_verify_lazy(state, action, game_config),
+        step_count=state.step_count + 1,
+    )
+    state = jax.lax.cond(
+        (state.terminated | state.truncated) | is_illegal,
+        lambda: state,
+        lambda: stepped_state,
+    )
+    return state, is_illegal
 
 
 def _finalize_step_state(
@@ -658,38 +784,6 @@ def _finalize_step_state(
         ),
         lambda: state,
     )
-
-
-def _step_lazy(state: State, action: Array, game_config: Optional[GameConfig] = None) -> State:
-    action_history = _append_action_history(state, action)
-    state = _replace_state(state, action_history=action_history)
-    state = _dispatch_step_lazy(state, action, game_config)
-    return _finalize_step_state(state, game_config, update_shanten=TRUE)
-
-
-def verify_step(
-    state: State,
-    action: Array,
-    game_config: Optional[GameConfig] = None,
-) -> tuple[State, Array]:
-    is_illegal = ~state.legal_action_mask[action]
-    stepped_state = _replace_state(
-        _step_verify_lazy(state, action, game_config),
-        step_count=state.step_count + 1,
-    )
-    state = jax.lax.cond(
-        (state.terminated | state.truncated) | is_illegal,
-        lambda: state,
-        lambda: stepped_state,
-    )
-    return state, is_illegal
-
-
-def _step_verify_lazy(state: State, action: Array, game_config: Optional[GameConfig] = None) -> State:
-    action_history = _append_action_history(state, action)
-    state = _replace_state(state, action_history=action_history)
-    state = _dispatch_step_lazy(state, action, game_config)
-    return _finalize_step_state(state, game_config, update_shanten=FALSE)
 
 
 def _draw(state: State, game_config: Optional[GameConfig] = None) -> State:
@@ -2057,6 +2151,86 @@ def _next_round(
         dc == jnp.int8(3),
         lambda: final_start_state,
         lambda: rotate_state,  # Early return here
+    )
+
+
+def _advance_to_next_round_auto(
+    state: State,
+    game_config: Optional[GameConfig] = None,
+) -> State:
+    """``auto`` next_round_style round transition (no DUMMY sharing) for red_mahjong.
+
+    Mirrors ``no_red_mahjong._advance_to_next_round_auto``: called when
+    ``terminated_round`` becomes True (RON / TSUMO / 流局) and the env is not in
+    ``single`` mode. Branches into game-end (terminated=True with final score) or
+    next-round init state (rewards from the round-end step are preserved).
+    """
+    hora = state.players.has_won  # (4,)
+    is_tempai = state.players.can_win.any(axis=-1)  # (4,)
+    dealer = state.round_state.dealer
+
+    order = jnp.argsort(-state.round_state.score)
+    rank_points = (
+        jnp.zeros_like(state.round_state.score).at[order].set(state.round_state.order_points)
+    )
+    score_with_rank = state.round_state.score + rank_points
+    top_after_rank = jnp.argmax(score_with_rank)
+    final_score = score_with_rank.at[top_after_rank].add(10 * state.round_state.kyotaku)
+
+    is_eight_consecutive_deals = state.round_state.honba >= 8
+    has_other_than_dealer_won = hora.any() & ~hora[dealer]
+    will_dealer_continue = jnp.logical_or(
+        is_tempai[dealer] & ~has_other_than_dealer_won, hora[dealer]
+    ) & ~is_eight_consecutive_deals
+
+    top_pre_rank = jnp.argmax(state.round_state.score)
+    is_final_round = state.round_state.round == state.round_state.round_limit
+    has_dealer_end = jnp.logical_not(will_dealer_continue)
+    is_dealer_top = jnp.arange(4)[top_pre_rank] == state.round_state.dealer
+    has_minus_score = (state.round_state.score < 0).any()
+    _is_game_end = (
+        (is_final_round & has_dealer_end)
+        | has_minus_score
+        | (is_final_round & is_dealer_top)
+    )
+
+    next_round = jnp.where(will_dealer_continue, state.round_state.round, state.round_state.round + 1)
+    has_winner = hora.any()
+    next_honba = jnp.where(
+        ~has_winner | will_dealer_continue, state.round_state.honba + 1, 0
+    )
+    next_dealer = jnp.where(will_dealer_continue, dealer, (dealer + 1) % 4)
+
+    _, next_round_rng = jax.random.split(state.round_state.rng_key)
+    prepared = _prepare_next_round_assets(next_round_rng, game_config)
+    base_next = _make_state(
+        rng_key=next_round_rng,
+        current_player=next_dealer,
+        dealer=next_dealer,
+        seat_wind=_calc_wind(next_dealer),
+        round=next_round,
+        round_limit=state.round_state.round_limit,
+        order_points=state.round_state.order_points,
+        honba=next_honba,
+        kyotaku=state.round_state.kyotaku,
+        score=state.round_state.score,
+    )
+    next_round_state = _init_for_next_round_from_prepared(base_next, prepared, game_config)
+    next_round_state = _replace_state(next_round_state,
+        current_player=jnp.int8(next_round_state.round_state.dealer),
+        rewards=state.rewards,
+        step_count=state.step_count,
+    )
+
+    terminated_state = _replace_state(state,
+        score=jnp.int32(final_score),
+        terminated=TRUE,
+    )
+
+    return jax.lax.cond(
+        _is_game_end,
+        lambda: terminated_state,
+        lambda: next_round_state,
     )
 
 

--- a/mahjax/ui/game_manager.py
+++ b/mahjax/ui/game_manager.py
@@ -742,11 +742,12 @@ class GameManager:
         if env_id in ("red_mahjong", "no_red_mahjong") and agent.agent_id == "rule_based":
             agent = self.registry.get("rule_based_red")
         if env_id == "red_mahjong":
-            env = RedMahjong(round_mode=round_mode)
+            env = RedMahjong(round_mode=round_mode, next_round_style="dummy_share")
         else:
             env = RedMahjong(
                 round_mode=round_mode,
                 game_config=RedGameConfig(use_red_fives=jnp.bool_(False)),
+                next_round_style="dummy_share",
             )
         rng = jax.random.PRNGKey(seed)
         rng, init_key = jax.random.split(rng)

--- a/tests/no_red_mahjong/test_env.py
+++ b/tests/no_red_mahjong/test_env.py
@@ -36,7 +36,7 @@ from mahjax.no_red_mahjong.env import (
     NoRedMahjong,
     _replace_state,
 )
-env = NoRedMahjong()
+env = NoRedMahjong(round_mode="single")
 
 jitted_init = jax.jit(_init)
 jitted_step = jax.jit(_step)
@@ -1160,6 +1160,236 @@ class TestEnv(unittest.TestCase):
             f"{state.round_state.action_history[2, :final_step_count]} != {tsumogiri_history}"
         )
         self.assertEqual(final_step_count, (state.round_state.action_history[0] != -1).sum(), f"{final_step_count} != {(state.round_state.action_history[0] != -1).sum()}")
+
+
+class TestNextRoundStyle(unittest.TestCase):
+    """Verify the default ``auto`` next_round_style (no DUMMY sharing) and that
+    the opt-in ``dummy_share`` mode preserves the original DUMMY-rotation flow."""
+
+    def _ron_legal_mask(self, ron_player: int = 0):
+        return (
+            jnp.zeros((4, Action.NUM_ACTION), dtype=jnp.bool_)
+            .at[ron_player, Action.RON].set(True)
+        )
+
+    def test_default_is_auto(self):
+        e = NoRedMahjong()
+        self.assertEqual(e.next_round_style, "auto")
+
+    def test_invalid_style_raises(self):
+        with self.assertRaises(ValueError):
+            NoRedMahjong(next_round_style="bogus")  # type: ignore[arg-type]
+
+    def test_auto_ron_advances_to_next_round_in_one_step(self):
+        # half mode + normal: a single RON step should land us directly in the
+        # next round init state (no dummy phase).
+        env_auto = NoRedMahjong(round_mode="half", next_round_style="auto")
+        state = env_auto.init(jax.random.PRNGKey(7))
+        state = _replace_state(
+            state,
+            legal_action_mask=self._ron_legal_mask(0),
+            current_player=jnp.int8(0),
+        )
+        next_state = env_auto.step(state, jnp.int32(Action.RON))
+        self.assertFalse(bool(next_state.terminated))
+        self.assertFalse(bool(next_state.round_state.terminated_round))
+        self.assertEqual(int(next_state.round_state.dummy_count), 0)
+        # The new current_player is the (new) dealer of the next round.
+        self.assertEqual(
+            int(next_state.current_player), int(next_state.round_state.dealer)
+        )
+        # Legal action mask is NOT DUMMY-only — the next-round draw produced
+        # discard / TSUMOGIRI options for the new dealer.
+        self.assertFalse(
+            bool(next_state.legal_action_mask[Action.DUMMY])
+            and int(next_state.legal_action_mask.sum()) == 1
+        )
+
+    def test_dummy_share_ron_keeps_dummy_phase(self):
+        # half mode + round_end_share: a single RON step leaves us in the DUMMY
+        # sharing phase exactly as the legacy behavior.
+        env_share = NoRedMahjong(round_mode="half", next_round_style="dummy_share")
+        state = env_share.init(jax.random.PRNGKey(7))
+        state = _replace_state(
+            state,
+            legal_action_mask=self._ron_legal_mask(0),
+            current_player=jnp.int8(0),
+        )
+        next_state = env_share.step(state, jnp.int32(Action.RON))
+        self.assertFalse(bool(next_state.terminated))
+        self.assertTrue(bool(next_state.round_state.terminated_round))
+        self.assertEqual(int(next_state.round_state.dummy_count), 0)
+        # Only DUMMY is legal for every seat.
+        self.assertTrue(bool(next_state.players.legal_action_mask[:, Action.DUMMY].all()))
+
+    def test_auto_single_mode_terminates_like_legacy(self):
+        # single + normal: terminated_round should imply terminated (env-level rule).
+        env_auto = NoRedMahjong(round_mode="single", next_round_style="auto")
+        state = env_auto.init(jax.random.PRNGKey(11))
+        state = _replace_state(
+            state,
+            legal_action_mask=self._ron_legal_mask(0),
+            current_player=jnp.int8(0),
+        )
+        next_state = env_auto.step(state, jnp.int32(Action.RON))
+        self.assertTrue(bool(next_state.terminated))
+
+    def test_auto_game_end_sets_terminated_with_final_score(self):
+        # Final round (round == round_limit), dealer not top and no continuation
+        # ⇒ game ends. Confirm score = score + rank_points + kyotaku bonus.
+        env_auto = NoRedMahjong(round_mode="half", next_round_style="auto")
+        state = env_auto.init(jax.random.PRNGKey(3))
+        # Note: env.init overrides round_limit to 8 for half. Override it here
+        # so that the test setup matches the legacy state-level convention used
+        # by ``test_next_round`` (round == round_limit triggers ``is_final_round``).
+        state = _replace_state(
+            state,
+            legal_action_mask=jnp.zeros((4, Action.NUM_ACTION), dtype=jnp.bool_)
+                .at[0, Action.RON].set(True),
+            current_player=jnp.int8(0),
+            dealer=jnp.int8(0),
+            score=jnp.array([310, 310, 190, 190], dtype=jnp.int32),
+            init_wind=jnp.array([0, 1, 2, 3], dtype=jnp.int8),
+            round=jnp.int8(7),
+            round_limit=jnp.int8(7),
+            kyotaku=jnp.int8(3),
+            has_won=jnp.array([False, False, False, False], dtype=jnp.bool_),
+        )
+        next_state = env_auto.step(state, jnp.int32(Action.RON))
+        self.assertTrue(bool(next_state.terminated))
+        # Score reflects rank_points + kyotaku on top, matching the legacy
+        # round_end_share final-score computation.
+        expected = jnp.array([370, 320, 180, 160], dtype=jnp.int32)
+        # ``rewards`` from the RON itself were [0, 0, 0, 0] in this stub setup,
+        # so the final score should equal expected (score + rank_points + kyotaku).
+        self.assertTrue(
+            bool(jnp.all(next_state.round_state.score == expected)),
+            f"got {next_state.round_state.score}, expected {expected}",
+        )
+
+    def test_auto_preserves_rewards_across_round_transition(self):
+        # The reward vector produced by the RON-ending step must survive the
+        # auto-advance to the next round init.
+        env_auto = NoRedMahjong(round_mode="half", next_round_style="auto")
+        state = env_auto.init(jax.random.PRNGKey(99))
+        # Force a non-zero reward by setting last_player so _ron's payout is
+        # meaningful; we only inspect that the reward shape is intact.
+        state = _replace_state(
+            state,
+            legal_action_mask=self._ron_legal_mask(0),
+            current_player=jnp.int8(0),
+            last_player=jnp.int8(2),
+        )
+        next_state = env_auto.step(state, jnp.int32(Action.RON))
+        # Reward shape preserved
+        self.assertEqual(next_state.rewards.shape, (4,))
+        # Game continues (not the final round)
+        self.assertFalse(bool(next_state.terminated))
+
+
+class TestAutoDummyShareParity(unittest.TestCase):
+    """Assert that ``auto`` mode collapses the dummy_share rotation phase into
+    a single env.step while producing the same end state. ``mahjax_tenhou_test``
+    validates the dummy_share trajectory against real tenhou mjlogs; this
+    parity test bridges that validation across to ``auto``."""
+
+    def _ron_legal_mask(self, ron_player: int = 0):
+        return (
+            jnp.zeros((4, Action.NUM_ACTION), dtype=jnp.bool_)
+            .at[ron_player, Action.RON].set(True)
+        )
+
+    def _force_ron_state(self, env, key, ron_player: int = 0):
+        state = env.init(key)
+        return _replace_state(
+            state,
+            legal_action_mask=self._ron_legal_mask(ron_player),
+            current_player=jnp.int8(ron_player),
+        )
+
+    def test_auto_matches_dummy_share_at_mid_game_round_transition(self):
+        # auto's 1-step round transition == dummy_share's 5-step (RON + 4 DUMMY)
+        # transition, modulo:
+        # - step_count (auto +1, share +5)
+        # - rewards (auto preserves the round-end vector from the RON step;
+        #   dummy_share resets it to zero in the _make_state-based init)
+        env_auto = NoRedMahjong(round_mode="half", next_round_style="auto")
+        env_share = NoRedMahjong(round_mode="half", next_round_style="dummy_share")
+        key = jax.random.PRNGKey(2026)
+
+        state_auto = env_auto.step(
+            self._force_ron_state(env_auto, key), jnp.int32(Action.RON)
+        )
+        state_share = env_share.step(
+            self._force_ron_state(env_share, key), jnp.int32(Action.RON)
+        )
+        rewards_at_ron = state_share.rewards  # delivered at RON step in dummy_share
+        for _ in range(4):
+            state_share = env_share.step(state_share, jnp.int32(Action.DUMMY))
+
+        # Mid-game: both at next-round init.
+        self.assertFalse(bool(state_auto.terminated))
+        self.assertFalse(bool(state_share.terminated))
+        self.assertFalse(bool(state_auto.round_state.terminated_round))
+        self.assertFalse(bool(state_share.round_state.terminated_round))
+        self.assertEqual(int(state_auto.round_state.dummy_count), 0)
+        self.assertEqual(int(state_share.round_state.dummy_count), 0)
+
+        rs_a, rs_s = state_auto.round_state, state_share.round_state
+        self.assertEqual(int(state_auto.current_player), int(state_share.current_player))
+        self.assertEqual(int(rs_a.dealer), int(rs_s.dealer))
+        self.assertEqual(int(rs_a.round), int(rs_s.round))
+        self.assertEqual(int(rs_a.honba), int(rs_s.honba))
+        self.assertEqual(int(rs_a.kyotaku), int(rs_s.kyotaku))
+        self.assertTrue(bool(jnp.all(rs_a.score == rs_s.score)))
+        self.assertTrue(bool(jnp.all(rs_a.deck == rs_s.deck)))
+        self.assertTrue(bool(jnp.all(rs_a.dora_indicators == rs_s.dora_indicators)))
+        self.assertEqual(int(rs_a.next_deck_ix), int(rs_s.next_deck_ix))
+        self.assertEqual(int(rs_a.last_draw), int(rs_s.last_draw))
+
+        ps_a, ps_s = state_auto.players, state_share.players
+        self.assertTrue(bool(jnp.all(ps_a.hand == ps_s.hand)))
+        self.assertTrue(bool(jnp.all(ps_a.has_won == ps_s.has_won)))
+        self.assertTrue(bool(jnp.all(ps_a.legal_action_mask == ps_s.legal_action_mask)))
+        self.assertTrue(
+            bool(jnp.all(state_auto.legal_action_mask == state_share.legal_action_mask))
+        )
+
+        # auto preserves the round-end rewards; dummy_share's were delivered at
+        # the RON step (captured in rewards_at_ron) and zeroed afterwards.
+        self.assertTrue(bool(jnp.all(state_auto.rewards == rewards_at_ron)))
+
+    def test_auto_matches_dummy_share_at_game_end(self):
+        # When RON ends the game, auto terminates after the RON step; dummy_share
+        # terminates one step later (DUMMY 1 detects _is_game_end at dc==0).
+        # Compare the two terminal states: same terminated, same final score,
+        # same rewards.
+        env_auto = NoRedMahjong(round_mode="half", next_round_style="auto")
+        env_share = NoRedMahjong(round_mode="half", next_round_style="dummy_share")
+        key = jax.random.PRNGKey(2026)
+        forced = dict(
+            dealer=jnp.int8(0),
+            score=jnp.array([310, 310, 190, 190], dtype=jnp.int32),
+            init_wind=jnp.array([0, 1, 2, 3], dtype=jnp.int8),
+            round=jnp.int8(7),
+            round_limit=jnp.int8(7),
+            kyotaku=jnp.int8(3),
+            has_won=jnp.array([False, False, False, False], dtype=jnp.bool_),
+        )
+
+        state_auto = _replace_state(self._force_ron_state(env_auto, key), **forced)
+        state_share = _replace_state(self._force_ron_state(env_share, key), **forced)
+
+        state_auto = env_auto.step(state_auto, jnp.int32(Action.RON))
+        state_share = env_share.step(state_share, jnp.int32(Action.RON))
+        state_share = env_share.step(state_share, jnp.int32(Action.DUMMY))
+
+        self.assertTrue(bool(state_auto.terminated))
+        self.assertTrue(bool(state_share.terminated))
+        self.assertTrue(
+            bool(jnp.all(state_auto.round_state.score == state_share.round_state.score))
+        )
+        self.assertTrue(bool(jnp.all(state_auto.rewards == state_share.rewards)))
 
 
 if __name__ == "__main__":

--- a/tests/red_mahjong/test_env.py
+++ b/tests/red_mahjong/test_env.py
@@ -4,12 +4,14 @@ import jax.numpy as jnp
 from mahjax.red_mahjong.action import Action
 from mahjax.red_mahjong.constants import FIRST_DRAW_IDX
 from mahjax.red_mahjong.env import (
+    RedMahjong,
     _abortive_draw_normal,
     _draw,
     _init,
     _make_legal_action_mask_after_draw,
     _next_meld_player,
     _next_ron_player,
+    _replace_state,
     _step,
 )
 from mahjax.red_mahjong.state import default_state
@@ -82,3 +84,193 @@ def test_abortive_draw_payments_shape() -> None:
     next_state = _abortive_draw_normal(state)
     assert bool(next_state.round_state.terminated_round)
     assert next_state.rewards.shape == (4,)
+
+
+# ----------------- next_round_style tests -----------------
+
+
+def _ron_legal_mask(ron_player: int = 0):
+    return (
+        jnp.zeros((4, Action.NUM_ACTION), dtype=jnp.bool_)
+        .at[ron_player, Action.RON].set(True)
+    )
+
+
+def test_red_default_is_auto() -> None:
+    e = RedMahjong()
+    assert e.next_round_style == "auto"
+
+
+def test_red_invalid_style_raises() -> None:
+    import pytest as _pytest
+    with _pytest.raises(ValueError):
+        RedMahjong(next_round_style="bogus")  # type: ignore[arg-type]
+
+
+def test_red_auto_ron_advances_to_next_round_in_one_step() -> None:
+    env_auto = RedMahjong(round_mode="half", next_round_style="auto")
+    state = env_auto.init(jax.random.PRNGKey(7))
+    state = _replace_state(
+        state,
+        legal_action_mask=_ron_legal_mask(0),
+        current_player=jnp.int8(0),
+    )
+    next_state = env_auto.step(state, jnp.int32(Action.RON))
+    assert not bool(next_state.terminated)
+    assert not bool(next_state.round_state.terminated_round)
+    assert int(next_state.round_state.dummy_count) == 0
+    assert int(next_state.current_player) == int(next_state.round_state.dealer)
+    # Legal action mask is NOT DUMMY-only.
+    only_dummy = (
+        bool(next_state.legal_action_mask[Action.DUMMY])
+        and int(next_state.legal_action_mask.sum()) == 1
+    )
+    assert not only_dummy
+
+
+def test_red_dummy_share_ron_keeps_dummy_phase() -> None:
+    env_share = RedMahjong(round_mode="half", next_round_style="dummy_share")
+    state = env_share.init(jax.random.PRNGKey(7))
+    state = _replace_state(
+        state,
+        legal_action_mask=_ron_legal_mask(0),
+        current_player=jnp.int8(0),
+    )
+    next_state = env_share.step(state, jnp.int32(Action.RON))
+    assert not bool(next_state.terminated)
+    assert bool(next_state.round_state.terminated_round)
+    assert int(next_state.round_state.dummy_count) == 0
+    # Only DUMMY is legal for every seat.
+    assert bool(next_state.players.legal_action_mask[:, Action.DUMMY].all())
+
+
+def test_red_auto_single_mode_terminates_like_legacy() -> None:
+    env_auto = RedMahjong(round_mode="single", next_round_style="auto")
+    state = env_auto.init(jax.random.PRNGKey(11))
+    state = _replace_state(
+        state,
+        legal_action_mask=_ron_legal_mask(0),
+        current_player=jnp.int8(0),
+    )
+    next_state = env_auto.step(state, jnp.int32(Action.RON))
+    assert bool(next_state.terminated)
+
+
+def test_red_auto_game_end_sets_terminated_with_final_score() -> None:
+    env_auto = RedMahjong(round_mode="half", next_round_style="auto")
+    state = env_auto.init(jax.random.PRNGKey(3))
+    state = _replace_state(
+        state,
+        legal_action_mask=_ron_legal_mask(0),
+        current_player=jnp.int8(0),
+        dealer=jnp.int8(0),
+        score=jnp.array([310, 310, 190, 190], dtype=jnp.int32),
+        init_wind=jnp.array([0, 1, 2, 3], dtype=jnp.int8),
+        round=jnp.int8(7),
+        round_limit=jnp.int8(7),
+        kyotaku=jnp.int8(3),
+        has_won=jnp.array([False, False, False, False], dtype=jnp.bool_),
+    )
+    next_state = env_auto.step(state, jnp.int32(Action.RON))
+    assert bool(next_state.terminated)
+    expected = jnp.array([370, 320, 180, 160], dtype=jnp.int32)
+    assert bool(jnp.all(next_state.round_state.score == expected)), (
+        f"got {next_state.round_state.score}, expected {expected}"
+    )
+
+
+# ---------------- parity: auto vs dummy_share ----------------
+#
+# These tests assert that ``auto`` mode collapses the dummy_share rotation
+# phase into a single env.step while producing the same end state.
+# ``mahjax_tenhou_test`` validates the dummy_share trajectory against real
+# tenhou mjlogs; this parity test bridges that validation across to ``auto``.
+
+
+def _force_ron_state(env: RedMahjong, key, ron_player: int = 0):
+    state = env.init(key)
+    return _replace_state(
+        state,
+        legal_action_mask=_ron_legal_mask(ron_player),
+        current_player=jnp.int8(ron_player),
+    )
+
+
+def test_red_auto_matches_dummy_share_at_mid_game_round_transition() -> None:
+    """auto's 1-step round transition == dummy_share's 5-step (RON + 4 DUMMY)
+    transition, modulo:
+    - ``step_count`` (auto +1, share +5)
+    - ``rewards`` (auto preserves the round-end vector from the RON step;
+      dummy_share resets it to zero in the ``_make_state``-based init).
+    """
+    env_auto = RedMahjong(round_mode="half", next_round_style="auto")
+    env_share = RedMahjong(round_mode="half", next_round_style="dummy_share")
+    key = jax.random.PRNGKey(2026)
+
+    state_auto = env_auto.step(_force_ron_state(env_auto, key), jnp.int32(Action.RON))
+    state_share = env_share.step(_force_ron_state(env_share, key), jnp.int32(Action.RON))
+    rewards_at_ron = state_share.rewards  # round-end reward delivered at RON step in dummy_share
+    for _ in range(4):
+        state_share = env_share.step(state_share, jnp.int32(Action.DUMMY))
+
+    # Both must land in the next-round init: mid-game ⇒ not terminated, not terminated_round.
+    assert not bool(state_auto.terminated)
+    assert not bool(state_share.terminated)
+    assert not bool(state_auto.round_state.terminated_round)
+    assert not bool(state_share.round_state.terminated_round)
+    assert int(state_auto.round_state.dummy_count) == 0
+    assert int(state_share.round_state.dummy_count) == 0
+
+    rs_a, rs_s = state_auto.round_state, state_share.round_state
+    assert int(state_auto.current_player) == int(state_share.current_player)
+    assert int(rs_a.dealer) == int(rs_s.dealer)
+    assert int(rs_a.round) == int(rs_s.round)
+    assert int(rs_a.honba) == int(rs_s.honba)
+    assert int(rs_a.kyotaku) == int(rs_s.kyotaku)
+    assert bool(jnp.all(rs_a.score == rs_s.score))
+    assert bool(jnp.all(rs_a.deck == rs_s.deck))
+    assert bool(jnp.all(rs_a.dora_indicators == rs_s.dora_indicators))
+    assert int(rs_a.next_deck_ix) == int(rs_s.next_deck_ix)
+    assert int(rs_a.last_draw) == int(rs_s.last_draw)
+
+    ps_a, ps_s = state_auto.players, state_share.players
+    assert bool(jnp.all(ps_a.hand == ps_s.hand))
+    assert bool(jnp.all(ps_a.has_won == ps_s.has_won))
+    assert bool(jnp.all(ps_a.legal_action_mask == ps_s.legal_action_mask))
+    assert bool(jnp.all(state_auto.legal_action_mask == state_share.legal_action_mask))
+
+    # auto preserves the round-end rewards; dummy_share's were delivered at the
+    # RON step (captured in ``rewards_at_ron``) and zeroed afterwards.
+    assert bool(jnp.all(state_auto.rewards == rewards_at_ron))
+
+
+def test_red_auto_matches_dummy_share_at_game_end() -> None:
+    """When RON ends the game, auto terminates after the RON step; dummy_share
+    terminates one step later (DUMMY 1 detects ``_is_game_end`` at ``dc==0``).
+    Compare the two terminal states: same ``terminated``, same final ``score``,
+    same ``rewards``.
+    """
+    env_auto = RedMahjong(round_mode="half", next_round_style="auto")
+    env_share = RedMahjong(round_mode="half", next_round_style="dummy_share")
+    key = jax.random.PRNGKey(2026)
+    forced = dict(
+        dealer=jnp.int8(0),
+        score=jnp.array([310, 310, 190, 190], dtype=jnp.int32),
+        init_wind=jnp.array([0, 1, 2, 3], dtype=jnp.int8),
+        round=jnp.int8(7),
+        round_limit=jnp.int8(7),
+        kyotaku=jnp.int8(3),
+        has_won=jnp.array([False, False, False, False], dtype=jnp.bool_),
+    )
+
+    state_auto = _replace_state(_force_ron_state(env_auto, key), **forced)
+    state_share = _replace_state(_force_ron_state(env_share, key), **forced)
+
+    state_auto = env_auto.step(state_auto, jnp.int32(Action.RON))
+    state_share = env_share.step(state_share, jnp.int32(Action.RON))
+    state_share = env_share.step(state_share, jnp.int32(Action.DUMMY))
+
+    assert bool(state_auto.terminated)
+    assert bool(state_share.terminated)
+    assert bool(jnp.all(state_auto.round_state.score == state_share.round_state.score))
+    assert bool(jnp.all(state_auto.rewards == state_share.rewards))


### PR DESCRIPTION
- https://github.com/mjx-project/mjx/issues/643
これに倣って，dummy action によるround endでの情報shareを行っていたが，RL的には，不要ということで，分岐させることにした．詳細は [Document](https://nissymori.github.io/mahjax/)