### PR TITLE
[Visualization] Add option for hiding opponent hand in visualization

### DIFF
--- a/docs/visualization.md
+++ b/docs/visualization.md
@@ -98,7 +98,24 @@ mahjax.save_svg_animation(
 )
 ```
 
-## 3. Using the state method directly
+## 3. Hide opponent hands
+
+`save_svg(...)` and `save_svg_animation(...)` accept `show_all_hands` and `visible_player`.
+With `show_all_hands=False`, every player other than `visible_player` is drawn face-down (`back.svg`). Melds, river, dora and other public information are still shown.
+
+```python
+mahjax.save_svg(
+    state,
+    "round-en.svg",
+    language="en",
+    show_all_hands=False,
+    visible_player=0,
+)
+```
+
+The default is `show_all_hands=True` (all hands revealed), so existing code is unaffected.
+
+## 4. Using the state method directly
 
 For notebooks and quick experiments, the `State` object also exposes SVG helpers:
 
@@ -109,7 +126,7 @@ state.save_svg("snapshot.svg", language="ja")
 
 This is convenient when you already have a state in memory and do not need the top-level helper.
 
-## 4. Visualization examples
+## 5. Visualization examples
 
 MahJax already includes sample animations in both tile styles.
 
@@ -123,7 +140,7 @@ These examples are useful when you want to:
 - prepare documentation for users who do not know the kanji tile faces
 - compare how readable your examples are in `ja` and `en`
 
-## 5. Practical notes
+## 6. Practical notes
 
 - The output of `save_svg_animation(...)` is an **animated SVG**, not a GIF or MP4.
 - The same visualization API works for both `no_red_mahjong` and `red_mahjong`.

--- a/mahjax/_src/visualizer.py
+++ b/mahjax/_src/visualizer.py
@@ -228,12 +228,20 @@ def save_svg(
     scale: Optional[float] = None,
     language: Language = "ja",
     use_english: bool = False,
+    show_all_hands: bool = True,
+    visible_player: int = 0,
 ) -> None:
     if use_english:
         language = "en"
     backend = _mahjong_svg_backend(state.env_id)
     if backend is not None:
-        backend.save_svg(state, filename, language=language)
+        backend.save_svg(
+            state,
+            filename,
+            show_all_hands=show_all_hands,
+            visible_player=visible_player,
+            language=language,
+        )
         return
     v = Visualizer(color_theme=color_theme, scale=scale)
     v.get_dwg(states=state, use_english=use_english).saveas(filename)
@@ -248,6 +256,8 @@ def save_svg_animation(
     frame_duration_seconds: Optional[float] = None,
     language: Language = "ja",
     use_english: bool = False,
+    show_all_hands: bool = True,
+    visible_player: int = 0,
 ) -> None:
     if use_english:
         language = "en"
@@ -258,6 +268,8 @@ def save_svg_animation(
             filename,
             frame_duration_seconds=frame_duration_seconds
             or global_config.frame_duration_seconds,
+            show_all_hands=show_all_hands,
+            visible_player=visible_player,
             language=language,
         )
         return

--- a/mahjax/no_red_mahjong/visualization.py
+++ b/mahjax/no_red_mahjong/visualization.py
@@ -120,12 +120,14 @@ def save_svg(
     state: State,
     filename: str | Path,
     show_all_hands: bool = True,
+    visible_player: int = 0,
     language: Language = "ja",
 ) -> None:
     Path(filename).write_text(
         render_round_svg(
             state,
             show_all_hands=show_all_hands,
+            visible_player=visible_player,
             language=language,
         ),
         encoding="utf-8",
@@ -136,12 +138,14 @@ def render_svg_animation(
     states: Sequence[State],
     frame_duration_seconds: float = 0.2,
     show_all_hands: bool = True,
+    visible_player: int = 0,
     language: Language = "ja",
 ) -> str:
     return render_red_svg_animation(
         [to_red_visual_state(state) for state in states],
         frame_duration_seconds=frame_duration_seconds,
         show_all_hands=show_all_hands,
+        visible_player=visible_player,
         language=language,
     )
 
@@ -151,6 +155,7 @@ def save_svg_animation(
     filename: str | Path,
     frame_duration_seconds: float = 0.2,
     show_all_hands: bool = True,
+    visible_player: int = 0,
     language: Language = "ja",
 ) -> None:
     Path(filename).write_text(
@@ -158,6 +163,7 @@ def save_svg_animation(
             states,
             frame_duration_seconds=frame_duration_seconds,
             show_all_hands=show_all_hands,
+            visible_player=visible_player,
             language=language,
         ),
         encoding="utf-8",

--- a/mahjax/red_mahjong/visualization.py
+++ b/mahjax/red_mahjong/visualization.py
@@ -322,7 +322,7 @@ def _player_group(
     offset += _W
 
     meld_count = int(state.players.meld_counts[player])
-    for m in range(min(meld_count, MAX_MELDS_PER_PLAYER)):
+    for m in reversed(range(min(meld_count, MAX_MELDS_PER_PLAYER))):
         meld = state.players.melds[player, m]
         if bool(Meld.is_empty(meld)):
             continue
@@ -449,10 +449,16 @@ def save_svg(
     state: EnvState,
     filename: str | Path,
     show_all_hands: bool = True,
+    visible_player: int = 0,
     language: Language = "ja",
 ) -> None:
     Path(filename).write_text(
-        render_round_svg(state, show_all_hands=show_all_hands, language=language),
+        render_round_svg(
+            state,
+            show_all_hands=show_all_hands,
+            visible_player=visible_player,
+            language=language,
+        ),
         encoding="utf-8",
     )
 
@@ -514,6 +520,7 @@ def render_svg_animation(
     states: list[EnvState],
     frame_duration_seconds: float = 0.2,
     show_all_hands: bool = True,
+    visible_player: int = 0,
     language: Language = "ja",
 ) -> str:
     language = _normalize_language(language)
@@ -525,7 +532,12 @@ def render_svg_animation(
     style += f"@keyframes _k{{0%,{step}%{{visibility:visible}}{step * 1.000001}%,100%{{visibility:hidden}}}}"
     images: list[str] = []
     for i, state in enumerate(states):
-        svg = render_round_svg(state, show_all_hands=show_all_hands, language=language)
+        svg = render_round_svg(
+            state,
+            show_all_hands=show_all_hands,
+            visible_player=visible_player,
+            language=language,
+        )
         uri = "data:image/svg+xml;base64," + base64.b64encode(svg.encode("utf-8")).decode("ascii")
         frame_id = f"_fr{i:x}"
         images.append(
@@ -545,6 +557,7 @@ def save_svg_animation(
     filename: str | Path,
     frame_duration_seconds: float = 0.2,
     show_all_hands: bool = True,
+    visible_player: int = 0,
     language: Language = "ja",
 ) -> None:
     Path(filename).write_text(
@@ -552,6 +565,7 @@ def save_svg_animation(
             states,
             frame_duration_seconds=frame_duration_seconds,
             show_all_hands=show_all_hands,
+            visible_player=visible_player,
             language=language,
         ),
         encoding="utf-8",


### PR DESCRIPTION
## Summary

- Add `show_all_hands` / `visible_player` parameters to `save_svg` and `save_svg_animation` so callers can hide opponents' concealed hands in rendered SVG/PDF output. The rendering backend (`render_round_svg`) already supported these, but the wrapper layers (`mahjax/_src/visualizer.py`, `mahjax/no_red_mahjong/visualization.py`, `mahjax/red_mahjong/visualization.py`) did not pass them through.
- Defaults are unchanged (`show_all_hands=True`, `visible_player=0`), so existing callers behave the same.
- Reverse meld draw order so older melds sit on the outside and newer ones closer to the hand (one-line change: `reversed(...)` in `_player_group`). Previously the order was inverted, which looked unnatural.
- Update `workspace/visualization/render_red_mahjong_single_state_pdf.py` to use the new parameters as a demo.
- Add a short "Hide opponent hands" section to `docs/visualization.md`.
