### PR TITLE
[0.1.1] fix visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ rng, subrng = jax.random.split(rng)
 rngs = jax.random.split(subrng, batch_size)
 action = jnp.zeros((batch_size,), dtype=jnp.int8)
 state = step_fn(state, action, rngs)
+
+# Visualize
+save_svg(
+    state,
+    tile_style="bilingual", # default is "standard".
+)
 ```
 
 ## User interface

--- a/README.md
+++ b/README.md
@@ -89,10 +89,9 @@ state = step_fn(state, action, rngs)
 obs = obs_fn(state)
 
 # Visualize
-single_state = env.init(jax.random.PRNGKey(1))
 save_svg(
-    single_state,
-    "round.svg",
+    state,
+    "state.svg",
     tile_style="bilingual",  # default is "standard"
 )
 ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 ## Overview
 
-- 🚀 **Vectorized Environment:** Extremely fast (approx. **1.6M steps/sec** on 8x A100 GPUs).
+- 🚀 **Vectorized Environment:** Extremely fast (approx. **2M steps/sec** on 8x A100 GPUs).
 - 🎨 **Rich Visualization:** SVG-based visualization with bilingual support **for those unfamiliar with Kanji**.
 - 🎮 **Playable Interface:** A web-based UI allows you to play directly against the agents you train.
 - 📚 **RL Examples:** Simple examples for Behavior Cloning + PPO in the [`examples/`](https://github.com/nissymori/mahjax/tree/main/examples).
@@ -57,6 +57,7 @@ We basically follow the [Pgx](https://github.com/sotetsuk/pgx) API design.
 import jax
 import jax.numpy as jnp
 import mahjax
+from mahjax import save_svg
 
 batch_size = 10
 rng = jax.random.PRNGKey(0)
@@ -83,9 +84,6 @@ rng, subrng = jax.random.split(rng)
 rngs = jax.random.split(subrng, batch_size)
 action = jnp.zeros((batch_size,), dtype=jnp.int8)
 state = step_fn(state, action, rngs)
-
-# Get observation
-obs = obs_fn(state)
 ```
 
 ## User interface
@@ -126,8 +124,8 @@ Currently, MahJax supports the following rules:
 
 | Rule | id | Status | Code | Speed (steps/sec) |
 |------|------|--------|------|--------|
-| No-Red Mahjong | `no_red_mahjong` | ✅ | [no_red_mahjong](https://github.com/nissymori/mahjax/tree/main/mahjax/mahjax/no_red_mahjong) | ~1.6M |
-| Red Mahjong | `red_mahjong` | ✅ | [red_mahjong](https://github.com/nissymori/mahjax/tree/main/mahjax/mahjax/red_mahjong) | ~9M |
+| No-Red Mahjong | `no_red_mahjong` | ✅ | [no_red_mahjong](https://github.com/nissymori/mahjax/tree/main/mahjax/mahjax/no_red_mahjong) | ~2M |
+| Red Mahjong | `red_mahjong` | ✅ | [red_mahjong](https://github.com/nissymori/mahjax/tree/main/mahjax/mahjax/red_mahjong) | ~1M |
 | Selective Rules | - | 🚧 | - | - |
 | 3-player Mahjong | - | 🚧 | - | - |
 
@@ -137,7 +135,7 @@ For the detailed rule specification, see the [official Tenhou rules](https://ten
 
 `no_red_mahjong` implements 4-player riichi mahjong without red fives.
 This variant is intentionally simplified for speed, and excludes some rules such as abortive draws (`特殊流局`), pao, and double ron.
-If throughput is your priority, `no_red_mahjong` is the recommended option.
+If throughput is your priority, `no_red_mahjong` is the recommended option (roughly 2x faster).
 
 You can configure the environment with:
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@
 
 > [!NOTE]
 > Japanese Riichi Mahjong is a challenging multi-agent RL environment with *imperfect information*, *stochastic dynamics*, *more than two players*, and *high-dimensional observations*.
-> Mahjax aims to make Mahjong research more accessible to a broader RL community.
-> For newcommers, please see our [basic introduction](https://nissymori.github.io/mahjax/mahjong-basics/) and the *bilingual visualization*.
+> MahJax aims to make Mahjong research more accessible to a broader RL community.
+> For newcomers, please see our [basic introduction](https://nissymori.github.io/mahjax/mahjong-basics/) and the *bilingual visualization*.
 
 
 ## Overview
@@ -34,12 +34,12 @@ For more details, please refer to the [Documentation](https://nissymori.github.i
 
 ## Quick Start
 ### Install
-Mahjax is available on PyPI. Please make sure that your Python environment has `jax` and `jaxlib` installed, depending on your hardware setup.
+MahJax is available on PyPI. Please make sure that your Python environment has `jax` and `jaxlib` installed, depending on your hardware setup.
 ```bash
 pip install mahjax
 ```
 
-📣 Mahjax is currently under active development. If you prefer to use the latest codebase with the newest features, please clone the repository and install it in editable mode:
+📣 MahJax is currently under active development. If you prefer to use the latest codebase with the newest features, please clone the repository and install it in editable mode:
 
 ```bash
 git clone https://github.com/nissymori/mahjax.git
@@ -85,10 +85,15 @@ rngs = jax.random.split(subrng, batch_size)
 action = jnp.zeros((batch_size,), dtype=jnp.int8)
 state = step_fn(state, action, rngs)
 
+# Get observation
+obs = obs_fn(state)
+
 # Visualize
+single_state = env.init(jax.random.PRNGKey(1))
 save_svg(
-    state,
-    tile_style="bilingual", # default is "standard".
+    single_state,
+    "round.svg",
+    tile_style="bilingual",  # default is "standard"
 )
 ```
 
@@ -152,7 +157,7 @@ You can configure the environment with:
 
 ```python
 env = mahjax.make(
-    id="red_mahjong",
+    "red_mahjong",
     round_mode="single",
     observe_type="dict",
     order_points=[30, 10, -10, -30],
@@ -178,7 +183,7 @@ JAX-based environments
 Paper coming soon.
 
 ## Acknowledgement
-- [sotetsuk](https://github.com/sotetsuk): For general advice on the development of mahjax based on his experience developing pgx.
+- [sotetsuk](https://github.com/sotetsuk): For general advice on the development of MahJax based on his experience developing pgx.
 - [habara-k](https://github.com/habara-k): For developing core JAX components such as shanten and Yaku calculation.
 - [OkanoShinri](https://github.com/OkanoShinri): For the initial implementation of MahJax and its SVG visualization.
-- [easonyu0203](easonyu0203): For advice on PPO implementation in a multi-player imperfect-information game.
+- [easonyu0203](https://github.com/easonyu0203): For advice on PPO implementation in a multi-player imperfect-information game.

--- a/docs/api.md
+++ b/docs/api.md
@@ -8,7 +8,7 @@ pip install mahjax
 
 ## Usage
 
-We follow almost the same API as [pgx](https://github.com/sotetsuk/pgx). Below is the example of usage of mahjax.
+We follow almost the same API as [pgx](https://github.com/sotetsuk/pgx). Below is an example of MahJax usage.
 
 ```py
 import jax
@@ -62,7 +62,7 @@ Both `no_red_mahjong` and `red_mahjong` share the same nested state layout. The 
 | `legal_action_mask` | `(num_actions,)` | `bool` | Legal action mask for `current_player`. At terminal states this is set to all-`True` to avoid zero-division when normalizing action probabilities. |
 | `rewards` | `(4,)` | `float32` | 4-player reward vector for the **step that just ran**. Mahjong rewards are score deltas in hundreds of points (e.g. ron payments, tsumo payments, tenpai/noten settlement, illegal-action penalty). Zero in steps that produced no scoring event. |
 | `terminated` | `()` | `bool` | Game terminal. `True` once for the step that ends the game; remains `True` afterwards. After it goes `True`, subsequent `env.step` calls return the state unchanged with zero rewards. |
-| `truncated` | `()` | `bool` | Reserved for external truncation wrappers (e.g. `TimeLimit`). Mahjax does not itself produce truncated episodes. |
+| `truncated` | `()` | `bool` | Reserved for external truncation wrappers (e.g. `TimeLimit`). MahJax does not itself produce truncated episodes. |
 | `step_count` | `()` | `int32` | Total `env.step` calls applied so far. |
 | `players` | nested | `PlayerStateArrays` | Per-player arrays — see below. |
 | `round_state` | nested | `RoundState` | Round-level arrays — see below. |

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,13 +8,13 @@
 
 > [!NOTE]
 > Japanese Riichi Mahjong is a challenging multi-agent RL environment with *imperfect information*, *stochastic dynamics*, *more than two players*, and *high-dimensional observations*.
-> Mahjax aims to make Mahjong research more accessible to a broader RL community.
-> For newcommers, please see our [basic introduction](https://nissymori.github.io/mahjax/mahjong-basics/) and the *bilingual visualization*.
+> MahJax aims to make Mahjong research more accessible to a broader RL community.
+> For newcomers, please see our [basic introduction](https://nissymori.github.io/mahjax/mahjong-basics/) and the *bilingual visualization*.
 
 
 ## Overview
 
-- 🚀 **Vectorized Environment:** Extremely fast (approx. **1.6M steps/sec** on 8x A100 GPUs).
+- 🚀 **Vectorized Environment:** Extremely fast (approx. **2M steps/sec** on 8x A100 GPUs).
 - 🎨 **Rich Visualization:** SVG-based visualization with bilingual support **for those unfamiliar with Kanji**.
 - 🎮 **Playable Interface:** A web-based UI allows you to play directly against the agents you train.
 - 📚 **RL Examples:** Simple examples for Behavior Cloning + PPO in the [`examples/`](https://github.com/nissymori/mahjax/tree/main/examples).
@@ -23,12 +23,12 @@ For more details, please refer to the [Documentation](https://nissymori.github.i
 
 ## Quick Start
 ### Install
-Mahjax is available on PyPI. Please make sure that your Python environment has `jax` and `jaxlib` installed, depending on your hardware setup.
+MahJax is available on PyPI. Please make sure that your Python environment has `jax` and `jaxlib` installed, depending on your hardware setup.
 ```bash
 pip install mahjax
 ```
 
-📣 Mahjax is currently under active development. If you prefer to use the latest codebase with the newest features, please clone the repository and install it in editable mode:
+📣 MahJax is currently under active development. If you prefer to use the latest codebase with the newest features, please clone the repository and install it in editable mode:
 
 ```bash
 git clone https://github.com/nissymori/mahjax.git
@@ -46,6 +46,7 @@ We basically follow the [Pgx](https://github.com/sotetsuk/pgx) API design.
 import jax
 import jax.numpy as jnp
 import mahjax
+from mahjax import save_svg
 
 batch_size = 10
 rng = jax.random.PRNGKey(0)
@@ -75,6 +76,14 @@ state = step_fn(state, action, rngs)
 
 # Get observation
 obs = obs_fn(state)
+
+# Visualize
+single_state = env.init(jax.random.PRNGKey(1))
+save_svg(
+    single_state,
+    "round.svg",
+    tile_style="bilingual",  # default is "standard"
+)
 ```
 
 ## User interface
@@ -115,8 +124,8 @@ Currently, MahJax supports the following rules:
 
 | Rule | id | Status | Code | Speed (steps/sec) |
 |------|------|--------|------|--------|
-| No-Red Mahjong | `no_red_mahjong` | ✅ | [no_red_mahjong](https://github.com/nissymori/mahjax/tree/main/mahjax/mahjax/no_red_mahjong) | ~1.6M |
-| Red Mahjong | `red_mahjong` | ✅ | [red_mahjong](https://github.com/nissymori/mahjax/tree/main/mahjax/mahjax/red_mahjong) | ~9M |
+| No-Red Mahjong | `no_red_mahjong` | ✅ | [no_red_mahjong](https://github.com/nissymori/mahjax/tree/main/mahjax/mahjax/no_red_mahjong) | ~2M |
+| Red Mahjong | `red_mahjong` | ✅ | [red_mahjong](https://github.com/nissymori/mahjax/tree/main/mahjax/mahjax/red_mahjong) | ~1M |
 | Selective Rules | - | 🚧 | - | - |
 | 3-player Mahjong | - | 🚧 | - | - |
 
@@ -126,7 +135,7 @@ For the detailed rule specification, see the [official Tenhou rules](https://ten
 
 `no_red_mahjong` implements 4-player riichi mahjong without red fives.
 This variant is intentionally simplified for speed, and excludes some rules such as abortive draws (`特殊流局`), pao, and double ron.
-If throughput is your priority, `no_red_mahjong` is the recommended option.
+If throughput is your priority, `no_red_mahjong` is the recommended option (roughly 2x faster).
 
 You can configure the environment with:
 
@@ -137,7 +146,7 @@ You can configure the environment with:
 
 ```python
 env = mahjax.make(
-    id="red_mahjong",
+    "red_mahjong",
     round_mode="single",
     observe_type="dict",
     order_points=[30, 10, -10, -30],
@@ -163,7 +172,7 @@ JAX-based environments
 Paper coming soon.
 
 ## Acknowledgement
-- [sotetsuk](https://github.com/sotetsuk): For general advice on the development of mahjax based on his experience developing pgx.
+- [sotetsuk](https://github.com/sotetsuk): For general advice on the development of MahJax based on his experience developing pgx.
 - [habara-k](https://github.com/habara-k): For developing core JAX components such as shanten and Yaku calculation.
 - [OkanoShinri](https://github.com/OkanoShinri): For the initial implementation of MahJax and its SVG visualization.
-- [easonyu0203](easonyu0203): For advice on PPO implementation in a multi-player imperfect-information game.
+- [easonyu0203](https://github.com/easonyu0203): For advice on PPO implementation in a multi-player imperfect-information game.

--- a/docs/mahjong-basics.md
+++ b/docs/mahjong-basics.md
@@ -3,8 +3,8 @@
 This page is a short introduction to Japanese riichi mahjong for newcomers.
 MahJax ships with two tile sets:
 
-- `ja`: the original tile faces
-- `en`: an English-friendly tile set with the same game information
+- `standard`: the original tile faces
+- `bilingual`: an English-friendly tile set with the same game information
 
 The first half of this page shows both side by side, so you can learn the game and the tile notation at the same time.
 
@@ -29,7 +29,7 @@ The numbered suits are:
 - **Circles (pinzu)** (`p`)
 - **Bamboos (souzu)** (`s`)
 
-| Group | Original tiles | English tiles |
+| Group | Standard tiles | Bilingual tiles |
 | --- | --- | --- |
 | Characters (manzu) | ![1m](assets/tiles/ja/1m.svg){ width="34" } ![2m](assets/tiles/ja/2m.svg){ width="34" } ![3m](assets/tiles/ja/3m.svg){ width="34" } ![4m](assets/tiles/ja/4m.svg){ width="34" } ![5m](assets/tiles/ja/5m.svg){ width="34" } ![6m](assets/tiles/ja/6m.svg){ width="34" } ![7m](assets/tiles/ja/7m.svg){ width="34" } ![8m](assets/tiles/ja/8m.svg){ width="34" } ![9m](assets/tiles/ja/9m.svg){ width="34" } | ![1m](assets/tiles/en/1m.svg){ width="34" } ![2m](assets/tiles/en/2m.svg){ width="34" } ![3m](assets/tiles/en/3m.svg){ width="34" } ![4m](assets/tiles/en/4m.svg){ width="34" } ![5m](assets/tiles/en/5m.svg){ width="34" } ![6m](assets/tiles/en/6m.svg){ width="34" } ![7m](assets/tiles/en/7m.svg){ width="34" } ![8m](assets/tiles/en/8m.svg){ width="34" } ![9m](assets/tiles/en/9m.svg){ width="34" } |
 | Circles (pinzu) | ![1p](assets/tiles/ja/1p.svg){ width="34" } ![2p](assets/tiles/ja/2p.svg){ width="34" } ![3p](assets/tiles/ja/3p.svg){ width="34" } ![4p](assets/tiles/ja/4p.svg){ width="34" } ![5p](assets/tiles/ja/5p.svg){ width="34" } ![6p](assets/tiles/ja/6p.svg){ width="34" } ![7p](assets/tiles/ja/7p.svg){ width="34" } ![8p](assets/tiles/ja/8p.svg){ width="34" } ![9p](assets/tiles/ja/9p.svg){ width="34" } | ![1p](assets/tiles/en/1p.svg){ width="34" } ![2p](assets/tiles/en/2p.svg){ width="34" } ![3p](assets/tiles/en/3p.svg){ width="34" } ![4p](assets/tiles/en/4p.svg){ width="34" } ![5p](assets/tiles/en/5p.svg){ width="34" } ![6p](assets/tiles/en/6p.svg){ width="34" } ![7p](assets/tiles/en/7p.svg){ width="34" } ![8p](assets/tiles/en/8p.svg){ width="34" } ![9p](assets/tiles/en/9p.svg){ width="34" } |
@@ -40,7 +40,7 @@ The numbered suits are:
 Honor tiles are not numbered.
 They are the four winds and the three dragons.
 
-| Group | Original tiles | English tiles |
+| Group | Standard tiles | Bilingual tiles |
 | --- | --- | --- |
 | Winds | ![east](assets/tiles/ja/east.svg){ width="34" } ![south](assets/tiles/ja/south.svg){ width="34" } ![west](assets/tiles/ja/west.svg){ width="34" } ![north](assets/tiles/ja/north.svg){ width="34" } | ![east](assets/tiles/en/east.svg){ width="34" } ![south](assets/tiles/en/south.svg){ width="34" } ![west](assets/tiles/en/west.svg){ width="34" } ![north](assets/tiles/en/north.svg){ width="34" } |
 | Dragons | ![white](assets/tiles/ja/white.svg){ width="34" } ![green](assets/tiles/ja/gd.svg){ width="34" } ![red](assets/tiles/ja/rd.svg){ width="34" } | ![white](assets/tiles/en/white.svg){ width="34" } ![green](assets/tiles/en/gd.svg){ width="34" } ![red](assets/tiles/en/rd.svg){ width="34" } |
@@ -50,7 +50,7 @@ They are the four winds and the three dragons.
 Some rulesets include one special red 5 in each suit.
 MahJax can visualize those too.
 
-| Group | Original tiles | English tiles |
+| Group | Standard tiles | Bilingual tiles |
 | --- | --- | --- |
 | Red fives | ![5mr](assets/tiles/ja/5mr.svg){ width="34" } ![5pr](assets/tiles/ja/5pr.svg){ width="34" } ![5sr](assets/tiles/ja/5sr.svg){ width="34" } | ![5mr](assets/tiles/en/5mr.svg){ width="34" } ![5pr](assets/tiles/en/5pr.svg){ width="34" } ![5sr](assets/tiles/en/5sr.svg){ width="34" } |
 
@@ -63,7 +63,7 @@ Most winning hands in riichi mahjong are built from:
 
 The three basic building blocks are:
 
-| Unit | Original tiles | English tiles | Meaning |
+| Unit | Standard tiles | Bilingual tiles | Meaning |
 | --- | --- | --- | --- |
 | Sequence | <nobr>![4m](assets/tiles/ja/4m.svg){ width="34" } ![5m](assets/tiles/ja/5m.svg){ width="34" } ![6m](assets/tiles/ja/6m.svg){ width="34" }</nobr> | <nobr>![4m](assets/tiles/en/4m.svg){ width="34" } ![5m](assets/tiles/en/5m.svg){ width="34" } ![6m](assets/tiles/en/6m.svg){ width="34" }</nobr> | Three consecutive suit tiles. Honors cannot make sequences. |
 | Triplet | <nobr>![7p](assets/tiles/ja/7p.svg){ width="34" } ![7p](assets/tiles/ja/7p.svg){ width="34" } ![7p](assets/tiles/ja/7p.svg){ width="34" }</nobr> | <nobr>![7p](assets/tiles/en/7p.svg){ width="34" } ![7p](assets/tiles/en/7p.svg){ width="34" } ![7p](assets/tiles/en/7p.svg){ width="34" }</nobr> | Three identical tiles. |
@@ -73,8 +73,8 @@ Here is a complete standard hand:
 
 | Tile set | Hand |
 | --- | --- |
-| Orig. | <nobr>![1m](assets/tiles/ja/1m.svg){ width="34" } ![2m](assets/tiles/ja/2m.svg){ width="34" } ![3m](assets/tiles/ja/3m.svg){ width="34" } ![4m](assets/tiles/ja/4m.svg){ width="34" } ![5m](assets/tiles/ja/5m.svg){ width="34" } ![6m](assets/tiles/ja/6m.svg){ width="34" } ![7p](assets/tiles/ja/7p.svg){ width="34" } ![8p](assets/tiles/ja/8p.svg){ width="34" } ![9p](assets/tiles/ja/9p.svg){ width="34" } ![7s](assets/tiles/ja/7s.svg){ width="34" } ![7s](assets/tiles/ja/7s.svg){ width="34" } ![7s](assets/tiles/ja/7s.svg){ width="34" } ![east](assets/tiles/ja/east.svg){ width="34" } ![east](assets/tiles/ja/east.svg){ width="34" }</nobr> |
-| EN | <nobr>![1m](assets/tiles/en/1m.svg){ width="34" } ![2m](assets/tiles/en/2m.svg){ width="34" } ![3m](assets/tiles/en/3m.svg){ width="34" } ![4m](assets/tiles/en/4m.svg){ width="34" } ![5m](assets/tiles/en/5m.svg){ width="34" } ![6m](assets/tiles/en/6m.svg){ width="34" } ![7p](assets/tiles/en/7p.svg){ width="34" } ![8p](assets/tiles/en/8p.svg){ width="34" } ![9p](assets/tiles/en/9p.svg){ width="34" } ![7s](assets/tiles/en/7s.svg){ width="34" } ![7s](assets/tiles/en/7s.svg){ width="34" } ![7s](assets/tiles/en/7s.svg){ width="34" } ![east](assets/tiles/en/east.svg){ width="34" } ![east](assets/tiles/en/east.svg){ width="34" }</nobr> |
+| Std. | <nobr>![1m](assets/tiles/ja/1m.svg){ width="34" } ![2m](assets/tiles/ja/2m.svg){ width="34" } ![3m](assets/tiles/ja/3m.svg){ width="34" } ![4m](assets/tiles/ja/4m.svg){ width="34" } ![5m](assets/tiles/ja/5m.svg){ width="34" } ![6m](assets/tiles/ja/6m.svg){ width="34" } ![7p](assets/tiles/ja/7p.svg){ width="34" } ![8p](assets/tiles/ja/8p.svg){ width="34" } ![9p](assets/tiles/ja/9p.svg){ width="34" } ![7s](assets/tiles/ja/7s.svg){ width="34" } ![7s](assets/tiles/ja/7s.svg){ width="34" } ![7s](assets/tiles/ja/7s.svg){ width="34" } ![east](assets/tiles/ja/east.svg){ width="34" } ![east](assets/tiles/ja/east.svg){ width="34" }</nobr> |
+| Biling. | <nobr>![1m](assets/tiles/en/1m.svg){ width="34" } ![2m](assets/tiles/en/2m.svg){ width="34" } ![3m](assets/tiles/en/3m.svg){ width="34" } ![4m](assets/tiles/en/4m.svg){ width="34" } ![5m](assets/tiles/en/5m.svg){ width="34" } ![6m](assets/tiles/en/6m.svg){ width="34" } ![7p](assets/tiles/en/7p.svg){ width="34" } ![8p](assets/tiles/en/8p.svg){ width="34" } ![9p](assets/tiles/en/9p.svg){ width="34" } ![7s](assets/tiles/en/7s.svg){ width="34" } ![7s](assets/tiles/en/7s.svg){ width="34" } ![7s](assets/tiles/en/7s.svg){ width="34" } ![east](assets/tiles/en/east.svg){ width="34" } ![east](assets/tiles/en/east.svg){ width="34" }</nobr> |
 
 This hand is:
 
@@ -118,7 +118,7 @@ For beginners, the three most useful yaku to learn first are:
 - **All simples (tanyao)**
 - **Value honor triplet (yakuhai)**
 
-From this section onward, the examples use the English tiles only.
+From this section onward, the examples use the Bilingual tiles only.
 
 ### All simples (tanyao)
 

--- a/docs/rule.md
+++ b/docs/rule.md
@@ -1,6 +1,6 @@
 # Supported Mahjong Games
 
-Mahjax currently implements 4-player Japanese Riichi Mahjong variants.
+MahJax currently implements 4-player Japanese Riichi Mahjong variants.
 To get familiar with the basic rules, please refer to the official rulebook:
 [European Riichi Mahjong Rules (2025, EN)](http://mahjong-europe.org/portal/images/docs/Riichi-rules-2025-EN.pdf).
 
@@ -10,7 +10,7 @@ While different variants require different strategies due to their specific rule
 - Risk management (defense vs. attack)
 - Reading and inferring opponents’ hands
 
-At the moment, Mahjax provides only **No red (aka no red dora)** variant.
+MahJax currently provides both **No-Red Mahjong** and **Red Mahjong** variants.
 
 The “red” in red mahjong refers to **additional dora tiles assigned to 5 tiles** (usually 5m, 5p, 5s). This has a large impact on strategy:
 
@@ -34,14 +34,14 @@ These rules emphasize careful yaku construction and more traditional scoring wit
 ## Red Mahjong
 
 Red mahjong, especially the rule set used by [Tenhou](https://tenhou.net/), is currently the **most popular** variant both in AI research and in commercial online games.
-We are intended to include this rule in a near furture.
+MahJax includes a `red_mahjong` environment with red fives.
 
 ### Research Projects Using/Targeting Red Rules
 
 - [Suphx](https://arxiv.org/abs/2003.13590): First top-player level mahjong agent trained by Deep RL.
-- [Mjx](https://github.com/mjx-project/mjx): C++ based simulator for tenhou rule.
-- [Mortal](https://github.com/Equim-chan/Mortal): Rust-based simulator + agent traning code. They also provides the [reviewer](https://mjai.ekyu.moe/) by their trained agent.
-- [NAGA](https://naga.dmv.nico/naga_report/top/): Agent reached 10-dan in tenhou. They also provide a service to review the playlog by the agent.
+- [Mjx](https://github.com/mjx-project/mjx): C++-based simulator for Tenhou rules.
+- [Mortal](https://github.com/Equim-chan/Mortal): Rust-based simulator and agent training code. They also provide a [reviewer](https://mjai.ekyu.moe/) powered by their trained agent.
+- [NAGA](https://naga.dmv.nico/naga_report/top/): Agent that reached 10-dan on Tenhou. They also provide a service to review play logs with the agent.
 
 ### Games Using/Supporting Red Rules
 
@@ -54,10 +54,9 @@ These environments typically feature fast-paced play and high average hand value
 
 ## Future Pathways
 
-Planned future extensions for Mahjax include:
+Planned future extensions for MahJax include:
 
-- **Support tenhou rule (Most prioritized)**.
 - Supporting additional **4-player Japanese Riichi Mahjong** rule sets
 - Integrating **3-player Japanese Mahjong** rules
 
-These expansions aim to make Mahjax a more comprehensive platform for both Mahjong AI research and gameplay experimentation.
+These expansions aim to make MahJax a more comprehensive platform for both Mahjong AI research and gameplay experimentation.

--- a/docs/visualization.md
+++ b/docs/visualization.md
@@ -7,6 +7,11 @@ MahJax exposes two main helpers for SVG output:
 
 If you were looking for `save_animation`, the current public function name is **`save_svg_animation`**.
 
+Both helpers accept `tile_style`:
+
+- `tile_style="standard"`: default riichi mahjong tiles
+- `tile_style="bilingual"`: tiles with English-friendly labels for non-kanji readers
+
 ## 1. Save a single SVG
 
 The quickest path is:
@@ -39,7 +44,7 @@ state = env.init(jax.random.PRNGKey(0))
 mahjax.save_svg(state, "round-bilingual.svg", tile_style="bilingual")
 ```
 
-The `tile_style` switch changes the tile art. Use `tile_style="bilingual"` when your audience does not read kanji.
+The default is `tile_style="standard"`, so you only need to pass `tile_style` when you want the bilingual tile set.
 
 ## 2. Save an SVG animation
 
@@ -112,7 +117,7 @@ mahjax.save_svg(
 )
 ```
 
-The default is `show_all_hands=True` (all hands revealed), so existing code is unaffected.
+The default is `show_all_hands=True` (all hands revealed).
 
 ## 4. Using the state method directly
 

--- a/docs/visualization.md
+++ b/docs/visualization.md
@@ -15,7 +15,7 @@ The quickest path is:
 2. initialize a state
 3. call `mahjax.save_svg(...)`
 
-### Japanese tiles
+### Standard tiles
 
 ```python
 import jax
@@ -24,10 +24,10 @@ import mahjax
 env = mahjax.make("no_red_mahjong")
 state = env.init(jax.random.PRNGKey(0))
 
-mahjax.save_svg(state, "round-ja.svg", language="ja")
+mahjax.save_svg(state, "round-standard.svg")
 ```
 
-### English tiles
+### Bilingual tiles
 
 ```python
 import jax
@@ -36,17 +36,17 @@ import mahjax
 env = mahjax.make("no_red_mahjong")
 state = env.init(jax.random.PRNGKey(0))
 
-mahjax.save_svg(state, "round-en.svg", language="en")
+mahjax.save_svg(state, "round-bilingual.svg", tile_style="bilingual")
 ```
 
-The `language` switch changes the tile art, so `en` is useful when your audience does not read kanji.
+The `tile_style` switch changes the tile art. Use `tile_style="bilingual"` when your audience does not read kanji.
 
 ## 2. Save an SVG animation
 
 `save_svg_animation(...)` takes a list of states.
 The simplest way to build that list is to run the environment step by step and append every intermediate state.
 
-### Japanese tiles
+### Standard tiles
 
 ```python
 import jax
@@ -66,13 +66,12 @@ for _ in range(40):
 
 mahjax.save_svg_animation(
     history,
-    "round-ja-animation.svg",
+    "round-standard-animation.svg",
     frame_duration_seconds=0.4,
-    language="ja",
 )
 ```
 
-### English tiles
+### Bilingual tiles
 
 ```python
 import jax
@@ -92,9 +91,9 @@ for _ in range(40):
 
 mahjax.save_svg_animation(
     history,
-    "round-en-animation.svg",
+    "round-bilingual-animation.svg",
     frame_duration_seconds=0.4,
-    language="en",
+    tile_style="bilingual",
 )
 ```
 
@@ -106,8 +105,8 @@ With `show_all_hands=False`, every player other than `visible_player` is drawn f
 ```python
 mahjax.save_svg(
     state,
-    "round-en.svg",
-    language="en",
+    "round-bilingual.svg",
+    tile_style="bilingual",
     show_all_hands=False,
     visible_player=0,
 )
@@ -120,8 +119,8 @@ The default is `show_all_hands=True` (all hands revealed), so existing code is u
 For notebooks and quick experiments, the `State` object also exposes SVG helpers:
 
 ```python
-svg_text = state.to_svg(language="en")
-state.save_svg("snapshot.svg", language="ja")
+svg_text = state.to_svg(tile_style="bilingual")
+state.save_svg("snapshot.svg")
 ```
 
 This is convenient when you already have a state in memory and do not need the top-level helper.
@@ -130,21 +129,21 @@ This is convenient when you already have a state in memory and do not need the t
 
 MahJax already includes sample animations in both tile styles.
 
-| Japanese tiles | English tiles |
+| Standard tiles | Bilingual tiles |
 | --- | --- |
-| ![Japanese tile animation](assets/red_mahjong_random_ja.gif) | ![English tile animation](assets/red_mahjong_random_en.gif) |
+| ![Standard tile animation](assets/red_mahjong_random_ja.gif) | ![Bilingual tile animation](assets/red_mahjong_random_en.gif) |
 
 These examples are useful when you want to:
 
 - show the same round state to Japanese and non-Japanese readers
 - prepare documentation for users who do not know the kanji tile faces
-- compare how readable your examples are in `ja` and `en`
+- compare how readable your examples are with `standard` and `bilingual` tiles
 
 ## 6. Practical notes
 
 - The output of `save_svg_animation(...)` is an **animated SVG**, not a GIF or MP4.
 - The same visualization API works for both `no_red_mahjong` and `red_mahjong`.
 - `frame_duration_seconds` controls playback speed.
-- For riichi mahjong in MahJax, `language="en"` is the switch you want for non-kanji readers.
+- For riichi mahjong in MahJax, `tile_style="bilingual"` is the switch you want for non-kanji readers.
 
 For a beginner-facing explanation of the tile set itself, see [Mahjong Basics](mahjong-basics.md).

--- a/mahjax/__init__.py
+++ b/mahjax/__init__.py
@@ -18,7 +18,7 @@ from mahjax.red_mahjong.state import (
 from mahjax.red_mahjong.tile import River, Tile
 from mahjax.red_mahjong.yaku import Yaku
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 __all__ = [
     # types

--- a/mahjax/_src/visualizer.py
+++ b/mahjax/_src/visualizer.py
@@ -23,7 +23,7 @@ import svgwrite  # type: ignore
 from mahjax.core import State
 
 ColorTheme = Literal["light", "dark"]
-Language = Literal["ja", "en"]
+TileStyle = Literal["standard", "bilingual"]
 
 
 @dataclass
@@ -96,7 +96,6 @@ class Visualizer:
     def get_dwg(
         self,
         states,
-        use_english=False,
     ):
         try:
             SIZE = len(states.current_player)
@@ -112,7 +111,7 @@ class Visualizer:
             WIDTH = 1
             HEIGHT = 1
 
-        self._set_config_by_state(states, use_english=use_english)
+        self._set_config_by_state(states)
         assert self._make_dwg_group is not None
 
         GRID_SIZE = self.config["GRID_SIZE"]
@@ -189,8 +188,7 @@ class Visualizer:
         dwg.add(group)
         return dwg
 
-    def _set_config_by_state(self, _state: State, use_english=False):  # noqa: C901
-        del use_english
+    def _set_config_by_state(self, _state: State):  # noqa: C901
         raise NotImplementedError(
             "DWG-based board renderer is removed for mahjong. Use SVG-based renderer via state.to_svg()/save_svg()."
         )
@@ -226,13 +224,10 @@ def save_svg(
     *,
     color_theme: Optional[Literal["light", "dark"]] = None,
     scale: Optional[float] = None,
-    language: Language = "ja",
-    use_english: bool = False,
+    tile_style: TileStyle = "standard",
     show_all_hands: bool = True,
     visible_player: int = 0,
 ) -> None:
-    if use_english:
-        language = "en"
     backend = _mahjong_svg_backend(state.env_id)
     if backend is not None:
         backend.save_svg(
@@ -240,11 +235,11 @@ def save_svg(
             filename,
             show_all_hands=show_all_hands,
             visible_player=visible_player,
-            language=language,
+            tile_style=tile_style,
         )
         return
     v = Visualizer(color_theme=color_theme, scale=scale)
-    v.get_dwg(states=state, use_english=use_english).saveas(filename)
+    v.get_dwg(states=state).saveas(filename)
 
 
 def save_svg_animation(
@@ -254,13 +249,10 @@ def save_svg_animation(
     color_theme: Optional[Literal["light", "dark"]] = None,
     scale: Optional[float] = None,
     frame_duration_seconds: Optional[float] = None,
-    language: Language = "ja",
-    use_english: bool = False,
+    tile_style: TileStyle = "standard",
     show_all_hands: bool = True,
     visible_player: int = 0,
 ) -> None:
-    if use_english:
-        language = "en"
     backend = _mahjong_svg_backend(states[0].env_id)
     if backend is not None:
         backend.save_svg_animation(
@@ -270,7 +262,7 @@ def save_svg_animation(
             or global_config.frame_duration_seconds,
             show_all_hands=show_all_hands,
             visible_player=visible_player,
-            language=language,
+            tile_style=tile_style,
         )
         return
     v = Visualizer(color_theme=color_theme, scale=scale)
@@ -281,7 +273,7 @@ def save_svg_animation(
     frame_groups = []
     dwg = None
     for i, state in enumerate(states):
-        dwg = v.get_dwg(states=state, use_english=use_english)
+        dwg = v.get_dwg(states=state)
         assert (
             len([e for e in dwg.elements if type(e) is svgwrite.container.Group]) == 1
         ), "Drawing must contain only one group"

--- a/mahjax/core.py
+++ b/mahjax/core.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import abc
-import warnings
 from typing import Literal, Optional, Tuple, get_args
 
 import jax
@@ -84,8 +83,7 @@ class State(abc.ABC):
         *,
         color_theme: Optional[Literal["light", "dark"]] = None,
         scale: Optional[float] = None,
-        language: Literal["ja", "en"] = "ja",
-        use_english: bool = False,
+        tile_style: Literal["standard", "bilingual"] = "standard",
     ) -> str:
         """Return SVG string. Useful for visualization in notebook.
 
@@ -103,17 +101,15 @@ class State(abc.ABC):
                 from mahjax.no_red_mahjong.visualization import render_round_svg
 
             del color_theme, scale
-            if use_english:
-                language = "en"
             return render_round_svg(
                 self,
                 show_all_hands=True,
-                language=language,
+                tile_style=tile_style,
             )
 
         from mahjax._src.visualizer import Visualizer
         v = Visualizer(color_theme=color_theme, scale=scale)
-        return v.get_dwg(states=self, use_english=use_english).tostring()
+        return v.get_dwg(states=self).tostring()
 
     def save_svg(
         self,
@@ -121,8 +117,7 @@ class State(abc.ABC):
         *,
         color_theme: Optional[Literal["light", "dark"]] = None,
         scale: Optional[float] = None,
-        language: Literal["ja", "en"] = "ja",
-        use_english: bool = False,
+        tile_style: Literal["standard", "bilingual"] = "standard",
     ) -> None:
         """Save the entire state (not observation) to a file.
         The filename must end with `.svg`
@@ -141,8 +136,7 @@ class State(abc.ABC):
             filename,
             color_theme=color_theme,
             scale=scale,
-            language=language,
-            use_english=use_english,
+            tile_style=tile_style,
         )
 
 

--- a/mahjax/no_red_mahjong/visualization.py
+++ b/mahjax/no_red_mahjong/visualization.py
@@ -16,7 +16,7 @@ from mahjax.red_mahjong.visualization import (
 
 from .state import State
 
-Language = Literal["ja", "en"]
+TileStyle = Literal["standard", "bilingual"]
 
 
 _SHARED_PLAYER_FIELDS = (
@@ -106,13 +106,13 @@ def render_round_svg(
     state: State,
     show_all_hands: bool = True,
     visible_player: int = 0,
-    language: Language = "ja",
+    tile_style: TileStyle = "standard",
 ) -> str:
     return render_red_round_svg(
         to_red_visual_state(state),
         show_all_hands=show_all_hands,
         visible_player=visible_player,
-        language=language,
+        tile_style=tile_style,
     )
 
 
@@ -121,14 +121,14 @@ def save_svg(
     filename: str | Path,
     show_all_hands: bool = True,
     visible_player: int = 0,
-    language: Language = "ja",
+    tile_style: TileStyle = "standard",
 ) -> None:
     Path(filename).write_text(
         render_round_svg(
             state,
             show_all_hands=show_all_hands,
             visible_player=visible_player,
-            language=language,
+            tile_style=tile_style,
         ),
         encoding="utf-8",
     )
@@ -139,14 +139,14 @@ def render_svg_animation(
     frame_duration_seconds: float = 0.2,
     show_all_hands: bool = True,
     visible_player: int = 0,
-    language: Language = "ja",
+    tile_style: TileStyle = "standard",
 ) -> str:
     return render_red_svg_animation(
         [to_red_visual_state(state) for state in states],
         frame_duration_seconds=frame_duration_seconds,
         show_all_hands=show_all_hands,
         visible_player=visible_player,
-        language=language,
+        tile_style=tile_style,
     )
 
 
@@ -156,7 +156,7 @@ def save_svg_animation(
     frame_duration_seconds: float = 0.2,
     show_all_hands: bool = True,
     visible_player: int = 0,
-    language: Language = "ja",
+    tile_style: TileStyle = "standard",
 ) -> None:
     Path(filename).write_text(
         render_svg_animation(
@@ -164,7 +164,7 @@ def save_svg_animation(
             frame_duration_seconds=frame_duration_seconds,
             show_all_hands=show_all_hands,
             visible_player=visible_player,
-            language=language,
+            tile_style=tile_style,
         ),
         encoding="utf-8",
     )

--- a/mahjax/red_mahjong/visualization.py
+++ b/mahjax/red_mahjong/visualization.py
@@ -39,6 +39,7 @@ _SCORE_Y = _CENTER + _CENTER_BOX_SIZE / 2.0 - 10.0
 _RIICHI_BAR_Y = _CENTER + _CENTER_BOX_SIZE / 2.0 - 4.0
 _RIICHI_DOT_Y = _CENTER + _CENTER_BOX_SIZE / 2.0 + 1.0
 Language = Literal["ja", "en"]
+TileStyle = Literal["standard", "bilingual"]
 _PLAYER_WIND_LABELS = {
     "ja": ("東", "南", "西", "北"),
     "en": ("E", "S", "W", "N"),
@@ -50,10 +51,12 @@ _ROUND_WIND_LABELS = {
 _JA_FONT_FAMILY = "'Noto Sans CJK JP', 'Noto Sans CJK', sans-serif"
 
 
-def _normalize_language(language: Language | str) -> Language:
-    if language not in ("ja", "en"):
-        raise ValueError(f"Unsupported language: {language}")
-    return language
+def _tile_style_to_language(tile_style: TileStyle | str) -> Language:
+    if tile_style == "standard":
+        return "ja"
+    if tile_style == "bilingual":
+        return "en"
+    raise ValueError(f"Unsupported tile_style: {tile_style}")
 
 
 def _is_red_tile(tile: int) -> bool:
@@ -384,9 +387,9 @@ def render_round_svg(
     state: EnvState,
     show_all_hands: bool = True,
     visible_player: int = 0,
-    language: Language = "ja",
+    tile_style: TileStyle = "standard",
 ) -> str:
-    language = _normalize_language(language)
+    language = _tile_style_to_language(tile_style)
     dora = [int(tile) for tile in jnp.asarray(state.round_state.dora_indicators) if int(tile) >= 0][:4]
     round_index = int(state.round_state.round)
     if language == "ja":
@@ -450,14 +453,14 @@ def save_svg(
     filename: str | Path,
     show_all_hands: bool = True,
     visible_player: int = 0,
-    language: Language = "ja",
+    tile_style: TileStyle = "standard",
 ) -> None:
     Path(filename).write_text(
         render_round_svg(
             state,
             show_all_hands=show_all_hands,
             visible_player=visible_player,
-            language=language,
+            tile_style=tile_style,
         ),
         encoding="utf-8",
     )
@@ -468,9 +471,9 @@ def render_play_history_svg(
     columns: int = 3,
     padding: float = 20.0,
     show_all_hands: bool = True,
-    language: Language = "ja",
+    tile_style: TileStyle = "standard",
 ) -> str:
-    language = _normalize_language(language)
+    _tile_style_to_language(tile_style)
     if columns <= 0:
         raise ValueError("columns must be >= 1")
     if not states:
@@ -483,7 +486,11 @@ def render_play_history_svg(
         f'<rect x="0" y="0" width="{width:.0f}" height="{height:.0f}" fill="#ffffff" />',
     ]
     for idx, state in enumerate(states):
-        svg = render_round_svg(state, show_all_hands=show_all_hands, language=language)
+        svg = render_round_svg(
+            state,
+            show_all_hands=show_all_hands,
+            tile_style=tile_style,
+        )
         uri = "data:image/svg+xml;base64," + base64.b64encode(svg.encode("utf-8")).decode("ascii")
         col = idx % columns
         row = idx // columns
@@ -502,7 +509,7 @@ def save_play_history_svg(
     columns: int = 3,
     padding: float = 20.0,
     show_all_hands: bool = True,
-    language: Language = "ja",
+    tile_style: TileStyle = "standard",
 ) -> None:
     Path(filename).write_text(
         render_play_history_svg(
@@ -510,7 +517,7 @@ def save_play_history_svg(
             columns=columns,
             padding=padding,
             show_all_hands=show_all_hands,
-            language=language,
+            tile_style=tile_style,
         ),
         encoding="utf-8",
     )
@@ -521,9 +528,9 @@ def render_svg_animation(
     frame_duration_seconds: float = 0.2,
     show_all_hands: bool = True,
     visible_player: int = 0,
-    language: Language = "ja",
+    tile_style: TileStyle = "standard",
 ) -> str:
-    language = _normalize_language(language)
+    _tile_style_to_language(tile_style)
     if not states:
         raise ValueError("states must not be empty")
     total_seconds = frame_duration_seconds * len(states)
@@ -536,7 +543,7 @@ def render_svg_animation(
             state,
             show_all_hands=show_all_hands,
             visible_player=visible_player,
-            language=language,
+            tile_style=tile_style,
         )
         uri = "data:image/svg+xml;base64," + base64.b64encode(svg.encode("utf-8")).decode("ascii")
         frame_id = f"_fr{i:x}"
@@ -558,7 +565,7 @@ def save_svg_animation(
     frame_duration_seconds: float = 0.2,
     show_all_hands: bool = True,
     visible_player: int = 0,
-    language: Language = "ja",
+    tile_style: TileStyle = "standard",
 ) -> None:
     Path(filename).write_text(
         render_svg_animation(
@@ -566,7 +573,7 @@ def save_svg_animation(
             frame_duration_seconds=frame_duration_seconds,
             show_all_hands=show_all_hands,
             visible_player=visible_player,
-            language=language,
+            tile_style=tile_style,
         ),
         encoding="utf-8",
     )
@@ -611,11 +618,11 @@ def random_play_and_save_svg(
     filename: str | Path,
     seed: int = 0,
     max_steps: int = 80,
-    language: Language = "ja",
+    tile_style: TileStyle = "standard",
 ) -> EnvState:
     history = generate_play_history_states(seed=seed, max_steps=max_steps, policy="random")
     state = history[-1]
-    save_svg(state, filename, language=language)
+    save_svg(state, filename, tile_style=tile_style)
     return state
 
 
@@ -626,7 +633,7 @@ def random_play_history_and_save_svg(
     columns: int = 3,
     padding: float = 20.0,
     show_all_hands: bool = True,
-    language: Language = "ja",
+    tile_style: TileStyle = "standard",
 ) -> EnvState:
     history = generate_play_history_states(seed=seed, max_steps=max_steps, policy="random")
     state = history[-1]
@@ -636,7 +643,7 @@ def random_play_history_and_save_svg(
         columns=columns,
         padding=padding,
         show_all_hands=show_all_hands,
-        language=language,
+        tile_style=tile_style,
     )
     return state
 
@@ -648,7 +655,7 @@ def play_history_and_save_svg_animation(
     frame_duration_seconds: float = 0.2,
     show_all_hands: bool = True,
     policy: str = "first_legal",
-    language: Language = "ja",
+    tile_style: TileStyle = "standard",
 ) -> EnvState:
     history = generate_play_history_states(seed=seed, max_steps=max_steps, policy=policy)
     save_svg_animation(
@@ -656,6 +663,6 @@ def play_history_and_save_svg_animation(
         filename,
         frame_duration_seconds=frame_duration_seconds,
         show_all_hands=show_all_hands,
-        language=language,
+        tile_style=tile_style,
     )
     return history[-1]

--- a/mahjax/ui/app.py
+++ b/mahjax/ui/app.py
@@ -67,7 +67,7 @@ class VisibilityRequest(BaseModel):
 
 
 def create_app() -> FastAPI:
-    app = FastAPI(title="MahJax Human vs AI UI", version="0.1.0")
+    app = FastAPI(title="MahJax Human vs AI UI", version="0.1.1")
     manager = GameManager()
     manager_lock = asyncio.Lock()
     app.state.manager = manager

--- a/mahjax/ui/game_manager.py
+++ b/mahjax/ui/game_manager.py
@@ -586,13 +586,13 @@ class GameSession:
             red_state,
             show_all_hands=reveal_all_hands,
             visible_player=0,
-            language="ja",
+            tile_style="standard",
         )
         svg_english = render_round_svg(
             red_state,
             show_all_hands=reveal_all_hands,
             visible_player=0,
-            language="en",
+            tile_style="bilingual",
         )
         legal_view = None
         advance_view: Optional[Dict[str, Any]] = None
@@ -656,13 +656,13 @@ class GameSession:
             oriented,
             show_all_hands=reveal_all_hands,
             visible_player=0,
-            language="ja",
+            tile_style="standard",
         )
         svg_en = render_round_svg(
             oriented,
             show_all_hands=reveal_all_hands,
             visible_player=0,
-            language="en",
+            tile_style="bilingual",
         )
         legal_view = None
         advance_view: Optional[Dict[str, Any]] = None

--- a/tests/red_mahjong/test_visualize.py
+++ b/tests/red_mahjong/test_visualize.py
@@ -20,13 +20,13 @@ def test_render_round_svg_contains_svg_tag() -> None:
     assert "</svg>" in svg
 
 
-def test_render_round_svg_supports_english_language() -> None:
+def test_render_round_svg_supports_bilingual_tile_style() -> None:
     state = _collect_states(0)[0]
-    svg_ja = render_round_svg(state, show_all_hands=True, language="ja")
-    svg_en = render_round_svg(state, show_all_hands=True, language="en")
-    assert "東1局" in svg_ja
-    assert "East 1" in svg_en
-    assert svg_ja != svg_en
+    svg_standard = render_round_svg(state, show_all_hands=True, tile_style="standard")
+    svg_bilingual = render_round_svg(state, show_all_hands=True, tile_style="bilingual")
+    assert "東1局" in svg_standard
+    assert "East 1" in svg_bilingual
+    assert svg_standard != svg_bilingual
 
 
 def test_save_play_history_svg_for_10_steps() -> None:


### PR DESCRIPTION
## Summary

Prepare the `0.1.1` release.

This PR updates the visualization API terminology from language-based options to tile-style-based options:

- `tile_style="standard"` for the default riichi tile set
- `tile_style="bilingual"` for the English-friendly tile set

It also updates release metadata and fixes README/docs inconsistencies found during the release pass.