### PR TITLE
[Fix]: take red fives into account for the hand feature

### DIFF
--- a/examples/networks/red_network.py
+++ b/examples/networks/red_network.py
@@ -64,7 +64,7 @@ class FeatureExtractor(nn.Module):
         ).astype(jnp.int32)
 
         hand_emb = nn.Embed(
-            Tile.NUM_TILE_TYPE + 1,
+            Tile.NUM_TILE_TYPE_WITH_RED + 1,
             HAND_EMB_SIZE,
             embedding_init=orthogonal_init(),
         )(hand + 1)

--- a/mahjax/red_mahjong/observation.py
+++ b/mahjax/red_mahjong/observation.py
@@ -9,17 +9,17 @@ import jax
 def hand_counts_to_idx(counts: Array, fill: int = -1, hand_size: int = 14) -> Array:
     # Check the input in the JIT outer loop, but keep the minimum guard
     counts = counts.astype(jnp.int32)
-    # Each column of (34,4) is 0,1,2,3, and if (col_index < count) is True, then the tile is selected
+    # Each column of (37,4) is 0,1,2,3, and if (col_index < count) is True, then the tile is selected
     col = jnp.arange(4)[None, :]  # (1,4)
-    mask = col < counts[:, None]  # (34,4) bool
+    mask = col < counts[:, None]  # (37,4) bool
 
     # Value table: if selected, the tile index, if not selected, fill
-    tile_ids = jnp.tile(jnp.arange(34, dtype=jnp.int32)[:, None], (1, 4))  # (34,4)
-    vals = jnp.where(mask, tile_ids, fill)  # (34,4) The contents are i or -1
-    vals = vals.reshape(-1)  # (136,)
+    tile_ids = jnp.tile(jnp.arange(37, dtype=jnp.int32)[:, None], (1, 4))  # (37,4)
+    vals = jnp.where(mask, tile_ids, fill)  # (37,4) The contents are i or -1
+    vals = vals.reshape(-1)  # (148,)
 
     # Sort the mask by True(=1) to the front to move the True to the front
-    key = mask.reshape(-1).astype(jnp.int32)  # (136,)
+    key = mask.reshape(-1).astype(jnp.int32)  # (148,)
     # argsort is ascending, so -key moves True to the front
     order = jnp.argsort(-key, stable=True)
     sorted_vals = vals[order]
@@ -31,7 +31,7 @@ def hand_counts_to_idx(counts: Array, fill: int = -1, hand_size: int = 14) -> Ar
 
 def _observe_dict(state: State) -> Dict:
     """
-    - hand: (14,) player's hand [0-33], -1 means empty
+    - hand: (14,) player's hand [0-36], -1 means empty
     - last_draw: (1,) The last drawn tile [0-36], -1 means no draw
     - action history: (3, 200) action history [player, action(tile), tsumogiri], player index is relative to the current player in [0, 3], discards store the actual tile in [0, 36], non-discard actions store the raw action id in [0, 86], and tsumogiri is 0/1 for discards and -1 otherwise
     - shanten count: (1,) The number of shanten (0-6)
@@ -47,8 +47,8 @@ def _observe_dict(state: State) -> Dict:
     c_p = state.current_player
     c_p_based_order = (jnp.arange(4) + c_p) % 4
     # hand features
-    hand_c_p_34 = state.players.hand[c_p]
-    hand_c_p_14 = hand_counts_to_idx(hand_c_p_34)
+    hand_c_p_37 = state.players.hand_with_red[c_p]
+    hand_c_p_14 = hand_counts_to_idx(hand_c_p_37)
     # action histories
     player_history = state.round_state.action_history[0, :].astype(jnp.int32)  # (200,)
     valid_history = player_history >= 0  # default value is -1, so we need to mask it

--- a/tests/red_mahjong/test_observe.py
+++ b/tests/red_mahjong/test_observe.py
@@ -26,6 +26,9 @@ def _make_state():
     hand = hand.at[2, 18].set(1)
     hand = hand.at[3, 27].set(1)
 
+    # No red fives in this fixture, so the 37-type hand mirrors the 34-type one.
+    hand_with_red = state.players.hand_with_red.at[:, : Tile.NUM_TILE_TYPE].set(hand)
+
     can_win = state.players.can_win
     can_win = can_win.at[0, jnp.array([1, 3], dtype=jnp.int32)].set(True)
     can_win = can_win.at[1, 9].set(True)
@@ -60,6 +63,7 @@ def _make_state():
         legal_action_mask=legal_action_mask[0],
         players=state.players.replace(
             hand=hand,
+            hand_with_red=hand_with_red,
             can_win=can_win,
             legal_action_mask=legal_action_mask,
             melds=melds,


### PR DESCRIPTION
## Summary
In red-five mahjong (`red_mahjong`), the `hand` observation did not distinguish red fives, so the agent could not observe whether it was holding a red 5. This switches the hand feature to be based on `hand_with_red` (37 types), exposing red 5m/5p/5s as tokens 34/35/36. The consuming network's embedding vocabulary is updated to match.

## Motivation
- The old implementation used `state.players.hand[c_p]` (34 types), which folded red fives into the regular five, erasing them from the observation.
- A red five is effectively a dora and directly affects discard / call / push-fold decisions. Without it in the observation, the policy has no way to learn around it.

## Changes
- **`mahjax/red_mahjong/observation.py`**
  - Switch the hand to be based on `hand_with_red` (37 types) (`hand[c_p]` → `hand_with_red[c_p]`).
  - Generalize `hand_counts_to_idx` from 34 → 37 types (comments / docstring updated to [0-36] / (148,)).
  - `hand_with_red` keeps the black-five index free of reds and stores them separately at 34/35/36 (`Hand.to_34` adds them back downstream). **No double counting occurs; the total stays at 13/14 tiles.**
- **`examples/networks/red_network.py`**
  - Grow the hand embedding vocabulary from `NUM_TILE_TYPE + 1` (35) → `NUM_TILE_TYPE_WITH_RED + 1` (38).
  - Without this, the red-five tokens (34/35/36 → `hand+1` = 35/36/37) are out of range, and JAX's gather **silently clamps them to row 34 (tile type 33, "red dragon")**, collapsing all red fives into a single embedding (i.e., distinguished in the observation but indistinguishable to the model).

## Notes
- The `dora_indicators` embedding (same file) is intentionally left at `NUM_TILE_TYPE + 1`. The observation maps it to [0-33] via `to_tile_type`, and a dora indicator's red/black is irrelevant to dora calculation, so no change is needed.
