### PR TITLE
[Fix]: keep red fives in the dora-indicator feature

### DIFF
--- a/examples/networks/red_network.py
+++ b/examples/networks/red_network.py
@@ -133,7 +133,7 @@ class FeatureExtractor(nn.Module):
 
         dora_mask = (dora_indicators >= 0).astype(jnp.float32)
         dora_emb = nn.Embed(
-            Tile.NUM_TILE_TYPE + 1,
+            Tile.NUM_TILE_TYPE_WITH_RED + 1,
             HAND_EMB_SIZE,
             embedding_init=orthogonal_init(),
         )(dora_indicators + 1)

--- a/mahjax/red_mahjong/observation.py
+++ b/mahjax/red_mahjong/observation.py
@@ -1,6 +1,6 @@
 from typing import Dict
 import jax.numpy as jnp
-from mahjax.red_mahjong.env import State, Tile
+from mahjax.red_mahjong.env import State
 from mahjax.red_mahjong.env import Array
 import jax
 
@@ -42,7 +42,7 @@ def _observe_dict(state: State) -> Dict:
     - kyotaku: (1,) The kyotaku number
     - round wind: (1,) The round wind [0-3]
     - seat wind: (1,) The seat wind [0-3]
-    - dora indicators: (4,) The dora indicators [0-33], -1 means no dora
+    - dora indicators: (4,) The dora indicators [0-36] (red-aware), -1 means no dora
     """
     c_p = state.current_player
     c_p_based_order = (jnp.arange(4) + c_p) % 4
@@ -69,7 +69,10 @@ def _observe_dict(state: State) -> Dict:
     kyotaku = state.round_state.kyotaku
     prevalent_wind = jnp.int8(state.round_state.round // 4)
     seat_wind = state.round_state.seat_wind[c_p]
-    dora_indicators = jnp.where(state.round_state.dora_indicators[:4] >= 0, Tile.to_tile_type(state.round_state.dora_indicators[:4]), state.round_state.dora_indicators[:4])
+    # Keep red-aware [0-36]: a red five revealed as an indicator is dead, which is
+    # information-bearing for remaining-aka availability and opponent value inference,
+    # even though red/black does not change which tile is dora.
+    dora_indicators = state.round_state.dora_indicators[:4]  # (4,)
     return {
         "hand": hand_c_p_14,
         "last_draw": state.round_state.last_draw,

--- a/tests/red_mahjong/test_observe.py
+++ b/tests/red_mahjong/test_observe.py
@@ -121,7 +121,7 @@ def test_observe_dict_returns_relative_view() -> None:
     )
     np.testing.assert_array_equal(
         np.array(obs["dora_indicators"]),
-        np.array([0, 13, -1, -1], dtype=np.int8),
+        np.array([0, Tile.RED_FIVE["p"], -1, -1], dtype=np.int8),
     )
     assert obs["shanten_count"].item() == 1
     assert obs["furiten"].item() == 0


### PR DESCRIPTION
## Summary
In red-five mahjong (`red_mahjong`), the `dora_indicators` observation was collapsed via `to_tile_type` to [0-33], discarding whether an indicator is a red five. This keeps it red-aware ([0-36]) and bumps the consuming network's embedding to match.

## Motivation
Red/black does not change *which* tile is dora, so collapsing was harmless for dora computation. But a red five revealed as an indicator is a specific aka that is now **dead**, which bounds the remaining-aka pool, every player's max hand value, and opponent value inference. This information exists in **no other channel**: indicators come from the dead wall, so they never appear in `action_history` (unlike discards, which are already red-aware). Collapsing it therefore lost decision-relevant information that could not be recovered elsewhere.

pointed out at #47 by @Apricot-S. Thank you!

## Changes
- **`mahjax/red_mahjong/observation.py`**
  - `dora_indicators`: keep red-aware [0-36] instead of collapsing via `to_tile_type`. Removed the now-unused `Tile` import; docstring updated.
- **`examples/networks/red_network.py`**
  - Bump the dora embedding vocabulary `NUM_TILE_TYPE + 1` (35) → `NUM_TILE_TYPE_WITH_RED + 1` (38). Without this, red-five tokens (34/35/36 → `dora+1` = 35/36/37) are out of range and JAX's gather **silently clamps them to row 34** (tile type 33, "red dragon"), making the red indicator indistinguishable — defeating the purpose.
- **`tests/red_mahjong/test_observe.py`**
  - Update the dora-indicator expectation: a red 5p indicator now stays as token `35` (`Tile.RED_FIVE["p"]`) instead of collapsing to `13`.

## Notes
- `examples/networks/no_red_network.py` is intentionally left at the 34-vocab: the no-red variant has no red fives, so [0-33] is correct.
- If `obs["dora_indicators"]` is embedded anywhere else (e.g. the main training code), bump its vocabulary to 38 as well — this PR only touches `examples/networks/red_network.py`.

## Test plan
- [x] `tests/red_mahjong/test_observe.py` passes.
- [x] End-to-end smoke test with a red 5p dora indicator: `dora_indicators` = `[0, 35, -1, -1]` and `FeatureExtractor` forward runs with no OOB.

