### PR TITLE
[Fix] return all 5 dora_indicators in observation and fix red docs

### DIFF
--- a/docs/no_red_mahjong.md
+++ b/docs/no_red_mahjong.md
@@ -93,7 +93,7 @@ The returned dictionary contains:
 | `kyotaku` | `()` | Riichi stick count. |
 | `prevalent_wind` | `()` | Current round wind information used by the environment. |
 | `seat_wind` | `()` | Current player's seat wind information used by the environment. |
-| `dora_indicators` | `(4,)` | Dora indicator tile types in `[0, 33]`; missing entries are `-1`. |
+| `dora_indicators` | `(5,)` | Dora indicator tile types in `[0, 33]`; missing entries are `-1`. |
 
 ### Action History
 

--- a/docs/red_mahjong.md
+++ b/docs/red_mahjong.md
@@ -133,7 +133,7 @@ The returned dictionary contains:
 | `kyotaku` | `()` | Riichi stick count. |
 | `prevalent_wind` | `()` | Prevailing wind. |
 | `seat_wind` | `()` | Current player's seat wind. |
-| `dora_indicators` | `(4,)` | Dora indicator tile **types** in `[0, 33]`; missing entries are `-1`. |
+| `dora_indicators` | `(5,)` | Dora indicator tiles in `[0, 36]` (red-aware); missing entries are `-1`. |
 
 ### Action History
 

--- a/mahjax/no_red_mahjong/observation.py
+++ b/mahjax/no_red_mahjong/observation.py
@@ -46,7 +46,7 @@ def _observe_dict(state: State) -> Dict:
     - kyotaku: (1,) The kyotaku number
     - round wind: (1,) The round wind [0-3]
     - seat wind: (1,) The seat wind [0-3]
-    - dora indicators: (4,) The dora indicators [0-33], -1 means no dora
+    - dora indicators: (5,) The dora indicators [0-33], -1 means no dora
     """
     c_p = state.current_player
     c_p_based_order = (jnp.arange(4) + c_p) % 4
@@ -75,7 +75,7 @@ def _observe_dict(state: State) -> Dict:
     kyotaku = state.round_state.kyotaku
     prevalent_wind = state.round_state.seat_wind[c_p]
     seat_wind = state.round_state.init_wind[c_p]
-    dora_indicators = state.round_state.dora_indicators[:4]  # (4,)
+    dora_indicators = state.round_state.dora_indicators[:5]  # (5,) Maximum 5 dora indicators
     return {
         "hand": hand_c_p_14,
         "last_draw": last_draw,

--- a/mahjax/red_mahjong/observation.py
+++ b/mahjax/red_mahjong/observation.py
@@ -42,7 +42,7 @@ def _observe_dict(state: State) -> Dict:
     - kyotaku: (1,) The kyotaku number
     - round wind: (1,) The round wind [0-3]
     - seat wind: (1,) The seat wind [0-3]
-    - dora indicators: (4,) The dora indicators [0-36] (red-aware), -1 means no dora
+    - dora indicators: (5,) The dora indicators [0-36] (red-aware), -1 means no dora
     """
     c_p = state.current_player
     c_p_based_order = (jnp.arange(4) + c_p) % 4
@@ -71,7 +71,7 @@ def _observe_dict(state: State) -> Dict:
     # Keep red-aware [0-36]: a red five revealed as an indicator is dead, which is
     # information-bearing for remaining-aka availability and opponent value inference,
     # even though red/black does not change which tile is dora.
-    dora_indicators = state.round_state.dora_indicators[:4]  # (4,)
+    dora_indicators = state.round_state.dora_indicators[:5]  # (5,) Maximum 5 dora indicators
     return {
         "hand": hand_c_p_14,
         "last_draw": state.round_state.last_draw,

--- a/mahjax/red_mahjong/visualization.py
+++ b/mahjax/red_mahjong/visualization.py
@@ -390,7 +390,7 @@ def render_round_svg(
     tile_style: TileStyle = "standard",
 ) -> str:
     language = _tile_style_to_language(tile_style)
-    dora = [int(tile) for tile in jnp.asarray(state.round_state.dora_indicators) if int(tile) >= 0][:4]
+    dora = [int(tile) for tile in jnp.asarray(state.round_state.dora_indicators) if int(tile) >= 0][:5]
     round_index = int(state.round_state.round)
     if language == "ja":
         round_label = f"{_ROUND_WIND_LABELS[language][round_index // 4]}{round_index % 4 + 1}局"

--- a/tests/no_red_mahjong/test_observe.py
+++ b/tests/no_red_mahjong/test_observe.py
@@ -78,7 +78,7 @@ class TestObserveDict(TestCase):
         self.assertEqual(obs["seat_wind"].item(), 2)
         np.testing.assert_array_equal(
             np.array(obs["dora_indicators"]),
-            np.array([0, 1, -1, -1], dtype=np.int32),
+            np.array([0, 1, -1, -1, -1], dtype=np.int32),
         )
 
     def test_action_history_relative_players(self):

--- a/tests/red_mahjong/test_observe.py
+++ b/tests/red_mahjong/test_observe.py
@@ -121,7 +121,7 @@ def test_observe_dict_returns_relative_view() -> None:
     )
     np.testing.assert_array_equal(
         np.array(obs["dora_indicators"]),
-        np.array([0, Tile.RED_FIVE["p"], -1, -1], dtype=np.int8),
+        np.array([0, Tile.RED_FIVE["p"], -1, -1, -1], dtype=np.int8),
     )
     assert obs["shanten_count"].item() == 1
     assert obs["furiten"].item() == 0


### PR DESCRIPTION
## Summary

Fix the `dora_indicators` observation to expose all 5 slots (matching internal state), and correct the red_mahjong value-range docs.

Closes #53
Closes #54

## Background

- Internal state holds 5 dora indicator slots (`MAX_DORA_INDICATORS = 5`) to support four-kan cases (1 dora + 4 kan-dora), but the dict observation sliced `[:4]`, dropping the 5th indicator (#53).
- #48 changed red_mahjong dora indicators to stay red-aware (`[0, 36]`) instead of normalizing red fives to black, but `docs/red_mahjong.md` still described the `[0, 33]` range (#54).

## Changes

**Observation (shape `(4,)` → `(5,)`)**
- `mahjax/no_red_mahjong/observation.py` — `dora_indicators[:4]` → `[:5]`, docstring updated to `(5,)`
- `mahjax/red_mahjong/observation.py` — same (`[:5]`, docstring `(5,)`)

**Docs**
- `docs/no_red_mahjong.md` — shape `(4,)` → `(5,)`
- `docs/red_mahjong.md` — shape `(4,)` → `(5,)`, value range `[0, 33]` → `[0, 36]` (red-aware), and reworded "tile **types**" to reflect red-aware tile ids (#54)

**Visualization**
- `mahjax/red_mahjong/visualization.py` — `[:4]` → `[:5]` so the 5th indicator is no longer dropped from the four-kan display

**Tests**
- `tests/no_red_mahjong/test_observe.py` / `tests/red_mahjong/test_observe.py` — expected arrays updated to 5 elements

> Note: the example networks (`examples/networks/*.py`) handle the dora axis shape-agnostically (mask + `sum(axis=1)`), so no change was needed.

## Test plan

- [x] `tests/{no_red,red}_mahjong/test_observe.py` pass
- [x] `tests/red_mahjong/test_visualize.py` passes
