### PR TITLE
docs: Add the missing trailing comma to the Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ env = mahjax.make(
     "red_mahjong",
     round_mode="single", # "single", "east" (tonpuusen), or "half" (hanchan)
     observe_type="dict", # "dict" for Transformer, "2D" for CNN
-    order_points=[30, 10, -10, -30] # Final score bonuses (uma)
+    order_points=[30, 10, -10, -30], # Final score bonuses (uma)
 )
 
 init_fn = jax.jit(jax.vmap(env.init))

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,7 +56,7 @@ env = mahjax.make(
     "red_mahjong",
     round_mode="single", # "single", "east" (tonpuusen), or "half" (hanchan)
     observe_type="dict", # "dict" for Transformer, "2D" for CNN
-    order_points=[30, 10, -10, -30] # Final score bonuses (uma)
+    order_points=[30, 10, -10, -30], # Final score bonuses (uma)
 )
 
 init_fn = jax.jit(jax.vmap(env.init))

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -49,7 +49,7 @@ app = create_app()
 app.state.manager.registry.load_callable_from_path(
     file_path=Path("path/to/my_agent_impl.py"),
     attribute="act",  # Function name in your file
-    description="My Custom Agent"
+    description="My Custom Agent",
 )
 ```
 


### PR DESCRIPTION
ドキュメント内で一部のみ最後の引数の末尾コンマがなかったため、他の箇所に合わせて追加します。
ドキュメントのみの変更なので動作には影響しません。