### PR TITLE
docs: Add the badge for the Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 [![License](https://img.shields.io/pypi/l/mahjax.svg)](https://pypi.org/project/mahjax)
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/mahjax.svg)](https://pypi.org/project/mahjax)
 [![arXiv](https://img.shields.io/badge/arXiv-2605.20577-b31b1b.svg)](https://arxiv.org/abs/2605.20577)
+[![Documentation](https://img.shields.io/badge/docs-available-8CA1AF?logo=readthedocs&logoColor=fff)](https://nissymori.github.io/mahjax/)
 
 **A GPU-Accelerated Mahjong Simulator for Reinforcement Learning in [JAX](https://github.com/google/jax)**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,8 @@
 [![PyPI](https://img.shields.io/pypi/v/mahjax.svg)](https://pypi.org/project/mahjax)
 [![License](https://img.shields.io/pypi/l/mahjax.svg)](https://pypi.org/project/mahjax)
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/mahjax.svg)](https://pypi.org/project/mahjax)
+[![arXiv](https://img.shields.io/badge/arXiv-2605.20577-b31b1b.svg)](https://arxiv.org/abs/2605.20577)
+[![Documentation](https://img.shields.io/badge/docs-available-8CA1AF?logo=readthedocs&logoColor=fff)](https://nissymori.github.io/mahjax/)
 
 **A GPU-Accelerated Mahjong Simulator for Reinforcement Learning in [JAX](https://github.com/google/jax)**
 


### PR DESCRIPTION
ドキュメントへのリンクのバッジを追加します。
バッジの画像は Pgx と同じものを使用しています。

また、index.md に arXiv へのリンクのバッジが無かったため、README.md に合わせて追加しています。

---

提案ですが、
About の Website にもドキュメントの URL を設定してはいかがでしょうか?
See also で紹介されている他 Env でもここにドキュメントの URL を設定しているものが複数あります。

歯車のボタンから設定できます。

<img width="443" height="160" alt="image" src="https://github.com/user-attachments/assets/4775d348-7ccd-46fb-8396-e8b1638ec9aa" />
