### PR TITLE
[codex] Add simplified Chinese UI localization

### DIFF
--- a/mahjax/ui/game_manager.py
+++ b/mahjax/ui/game_manager.py
@@ -114,6 +114,42 @@ YAKU_NAMES_JA = [
     "四暗刻",
     "四槓子",
 ]
+YAKU_NAMES_ZH_CN = [
+    "平和",
+    "一杯口",
+    "二杯口",
+    "混全带幺九",
+    "纯全带幺九",
+    "一气通贯",
+    "三色同顺",
+    "三色同刻",
+    "对对和",
+    "三暗刻",
+    "三杠子",
+    "七对子",
+    "断幺九",
+    "混一色",
+    "清一色",
+    "混老头",
+    "小三元",
+    "白",
+    "发",
+    "中",
+    "场风",
+    "自风",
+    "门前清自摸和",
+    "立直",
+    "大三元",
+    "小四喜",
+    "大四喜",
+    "九莲宝灯",
+    "国士无双",
+    "清老头",
+    "字一色",
+    "绿一色",
+    "四暗刻",
+    "四杠子",
+]
 RED_YAKU_NAMES_EN = [
     "Fully Concealed Hand",
     "Riichi",
@@ -172,7 +208,7 @@ RED_YAKU_NAMES_JA = [
     "門前清自摸和",
     "立直",
     "一発",
-    "槍槓",
+    "搶槓",
     "嶺上開花",
     "海底摸月",
     "河底撈魚",
@@ -222,25 +258,80 @@ RED_YAKU_NAMES_JA = [
     "小四喜",
     "四槓子",
 ]
+RED_YAKU_NAMES_ZH_CN = [
+    "门前清自摸和",
+    "立直",
+    "一发",
+    "抢杠",
+    "岭上开花",
+    "海底摸月",
+    "河底捞鱼",
+    "平和",
+    "断幺九",
+    "一杯口",
+    "自风 东",
+    "自风 南",
+    "自风 西",
+    "自风 北",
+    "场风 东",
+    "场风 南",
+    "场风 西",
+    "场风 北",
+    "白",
+    "发",
+    "中",
+    "两立直",
+    "七对子",
+    "混全带幺九",
+    "一气通贯",
+    "三色同顺",
+    "三色同刻",
+    "三杠子",
+    "对对和",
+    "三暗刻",
+    "小三元",
+    "混老头",
+    "二杯口",
+    "纯全带幺九",
+    "混一色",
+    "清一色",
+    "人和",
+    "天和",
+    "地和",
+    "大三元",
+    "四暗刻",
+    "四暗刻单骑",
+    "字一色",
+    "绿一色",
+    "清老头",
+    "九莲宝灯",
+    "纯正九莲宝灯",
+    "国士无双",
+    "国士无双十三面",
+    "大四喜",
+    "小四喜",
+    "四杠子",
+]
 
 
 class ExtraYakuDefinition(NamedTuple):
     english: str
     japanese: str
+    chinese: str
     attr: str
 
 
 EXTRA_RON_YAKU: List[ExtraYakuDefinition] = [
-    ExtraYakuDefinition("Ippatsu", "一発", "_ippatsu"),
-    ExtraYakuDefinition("Double Riichi", "ダブル立直", "_double_riichi"),
-    ExtraYakuDefinition("Robbing a Kan", "槍槓", "_kan_declared"),
-    ExtraYakuDefinition("Houtei Raoyui", "河底撈魚", "_is_haitei"),
+    ExtraYakuDefinition("Ippatsu", "一発", "一发", "_ippatsu"),
+    ExtraYakuDefinition("Double Riichi", "ダブル立直", "两立直", "_double_riichi"),
+    ExtraYakuDefinition("Robbing a Kan", "搶槓", "抢杠", "_kan_declared"),
+    ExtraYakuDefinition("Houtei Raoyui", "河底撈魚", "河底捞鱼", "_is_haitei"),
 ]
 EXTRA_TSUMO_YAKU: List[ExtraYakuDefinition] = [
-    ExtraYakuDefinition("Rinshan Kaihou", "嶺上開花", "_can_after_kan"),
-    ExtraYakuDefinition("Ippatsu", "一発", "_ippatsu"),
-    ExtraYakuDefinition("Double Riichi", "ダブル立直", "_double_riichi"),
-    ExtraYakuDefinition("Haitei Raoyue", "海底摸月", "_is_haitei"),
+    ExtraYakuDefinition("Rinshan Kaihou", "嶺上開花", "岭上开花", "_can_after_kan"),
+    ExtraYakuDefinition("Ippatsu", "一発", "一发", "_ippatsu"),
+    ExtraYakuDefinition("Double Riichi", "ダブル立直", "两立直", "_double_riichi"),
+    ExtraYakuDefinition("Haitei Raoyue", "海底摸月", "海底摸月", "_is_haitei"),
 ]
 
 
@@ -274,6 +365,7 @@ class WinnerSummary:
     fu: int
     yaku: List[str]
     yaku_japanese: List[str]
+    yaku_chinese: List[str]
     dora_count: int
     ura_dora_count: int
     dora_tiles: List[int]
@@ -297,6 +389,7 @@ class WinnerSummary:
             "yakuLocalized": {
                 "en": self.yaku,
                 "ja": self.yaku_japanese,
+                "zh-CN": self.yaku_chinese,
             },
             "dora": self.dora_count,
             "uraDora": self.ura_dora_count,
@@ -1414,23 +1507,30 @@ def summarise_winner(
     indices = [i for i, flag in enumerate(yaku_mask_np) if flag]
     yaku_english = [YAKU_NAMES_EN[i] for i in indices]
     yaku_japanese = [YAKU_NAMES_JA[i] for i in indices]
+    yaku_chinese = [YAKU_NAMES_ZH_CN[i] for i in indices]
     extra_definitions = EXTRA_RON_YAKU if is_ron else EXTRA_TSUMO_YAKU
     extras_english = list_extra_yaku(
-        prev_state, player, extra_definitions, use_english=True
+        prev_state, player, extra_definitions, language="en"
     )
     extras_japanese = list_extra_yaku(
-        prev_state, player, extra_definitions, use_english=False
+        prev_state, player, extra_definitions, language="ja"
+    )
+    extras_chinese = list_extra_yaku(
+        prev_state, player, extra_definitions, language="zh-CN"
     )
     if not is_ron:
         if is_first_turn(prev_state) and int(prev_state.players.meld_counts.sum()) == 0:
             if player == int(prev_state.round_state.dealer):
                 extras_english.append("Heavenly Hand")
                 extras_japanese.append("天和")
+                extras_chinese.append("天和")
             else:
                 extras_english.append("Earthly Hand")
                 extras_japanese.append("地和")
+                extras_chinese.append("地和")
     yaku_english.extend(extras_english)
     yaku_japanese.extend(extras_japanese)
+    yaku_chinese.extend(extras_chinese)
     riichi_yaku_flag = any(
         name in yaku_english for name in ("Riichi", "Double Riichi")
     )
@@ -1445,6 +1545,7 @@ def summarise_winner(
         fu=fu_val,
         yaku=yaku_english,
         yaku_japanese=yaku_japanese,
+        yaku_chinese=yaku_chinese,
         dora_count=visible_dora,
         ura_dora_count=ura_dora,
         dora_tiles=dora_tile_list,
@@ -1487,16 +1588,20 @@ def summarise_winner_red(
     indices = [i for i, flag in enumerate(yaku_mask_np) if flag]
     yaku_english = [RED_YAKU_NAMES_EN[i] for i in indices]
     yaku_japanese = [RED_YAKU_NAMES_JA[i] for i in indices]
+    yaku_chinese = [RED_YAKU_NAMES_ZH_CN[i] for i in indices]
     extra_definitions = EXTRA_RON_YAKU if is_ron else EXTRA_TSUMO_YAKU
-    yaku_english.extend(list_extra_yaku(prev_state, player, extra_definitions, use_english=True))
-    yaku_japanese.extend(list_extra_yaku(prev_state, player, extra_definitions, use_english=False))
+    yaku_english.extend(list_extra_yaku(prev_state, player, extra_definitions, language="en"))
+    yaku_japanese.extend(list_extra_yaku(prev_state, player, extra_definitions, language="ja"))
+    yaku_chinese.extend(list_extra_yaku(prev_state, player, extra_definitions, language="zh-CN"))
     if not is_ron and is_first_turn(prev_state) and int(np.array(prev_state.players.meld_counts).sum()) == 0:
         if player == int(prev_state.round_state.dealer):
             yaku_english.append("Heavenly Hand")
             yaku_japanese.append("天和")
+            yaku_chinese.append("天和")
         else:
             yaku_english.append("Earthly Hand")
             yaku_japanese.append("地和")
+            yaku_chinese.append("地和")
     yakuman = 0
     if fu_val == 0 and fan_val > 0:
         yakuman = fan_val
@@ -1509,6 +1614,7 @@ def summarise_winner_red(
         fu=fu_val,
         yaku=yaku_english,
         yaku_japanese=yaku_japanese,
+        yaku_chinese=yaku_chinese,
         dora_count=visible_dora,
         ura_dora_count=ura_dora,
         dora_tiles=dora_tile_list,
@@ -1535,7 +1641,7 @@ def list_extra_yaku(
     player: int,
     definitions: List[ExtraYakuDefinition],
     *,
-    use_english: bool,
+    language: str,
 ) -> List[str]:
     names: List[str] = []
     for definition in definitions:
@@ -1551,7 +1657,12 @@ def list_extra_yaku(
         else:
             flag = bool(value)
         if flag:
-            names.append(definition.english if use_english else definition.japanese)
+            if language == "en":
+                names.append(definition.english)
+            elif language == "zh-CN":
+                names.append(definition.chinese)
+            else:
+                names.append(definition.japanese)
     return names
 
 

--- a/mahjax/ui/static/app.js
+++ b/mahjax/ui/static/app.js
@@ -30,6 +30,7 @@ const actionTitleEl = document.getElementById('actionTitle');
 const scoreTitleEl = document.getElementById('scoreTitle');
 const eventsTitleEl = document.getElementById('eventsTitle');
 const scoreHeaderRow = document.getElementById('scoreHeaderRow');
+const pageTitleEl = document.querySelector('[data-i18n="index.title"]');
 const controlTextRefs = {
   env: document.querySelector('[data-i18n="controls.env"]'),
   agent: document.querySelector('[data-i18n="controls.agent"]'),
@@ -62,10 +63,11 @@ const seatOptionRefs = {
 };
 const LANGUAGE_BUTTON_SELECTOR = '#languageToggle .language-btn[data-lang]';
 
-const Languages = { JA: 'ja', EN: 'en' };
+const Languages = { JA: 'ja', EN: 'en', ZH_CN: 'zh-CN' };
 const I18N = {
   ja: {
     code: 'ja',
+    title: 'MahJax Human vs AI',
     you: 'あなた',
     relativeSeats: ['あなた', '下家', '対面', '上家'],
     honors: ['東', '南', '西', '北', '白', '發', '中'],
@@ -188,6 +190,7 @@ const I18N = {
   },
   en: {
     code: 'en',
+    title: 'MahJax Human vs AI',
     you: 'You',
     relativeSeats: ['You', 'Right Player', 'Across', 'Left Player'],
     honors: ['East', 'South', 'West', 'North', 'White', 'Green', 'Red'],
@@ -305,6 +308,126 @@ const I18N = {
       暗槓: 'Concealed Kan',
     },
   },
+  'zh-CN': {
+    code: 'zh-CN',
+    title: 'MahJax 人机对局',
+    you: '你',
+    relativeSeats: ['自家', '下家', '对家', '上家'],
+    honors: ['東', '南', '西', '北', '白', '發', '中'],
+    winds: {
+      東: '東',
+      南: '南',
+      西: '西',
+      北: '北',
+      白: '白',
+      發: '發',
+      中: '中',
+    },
+    sections: {
+      hand: '手牌',
+      actions: '行动',
+      score: '分数',
+      events: '日志',
+    },
+    controls: {
+      env: '规则',
+      agent: 'AI/代理',
+      mode: '模式',
+      humanSeat: '玩家位置',
+      seed: '随机种子',
+      humanName: '真人名称',
+      aiName: 'AI 名称前缀',
+      aiDelay: 'AI 思考延迟（毫秒）',
+      hideOpponents: '隐藏他家手牌',
+      noCalls: '自动跳过鸣牌',
+      start: '开始对局',
+      end: '结束对局',
+      modes: {
+        half: '半庄战',
+        east: '东风战',
+        single: '单局战',
+      },
+      seats: {
+        auto: '随机',
+        east: '东家',
+        south: '南家',
+        west: '西家',
+        north: '北家',
+      },
+      envs: {
+        no_red_mahjong: '无赤牌',
+        red_mahjong: '有赤牌',
+      },
+    },
+    scoreboardHeaders: ['座位', '名称', '点数', '增减'],
+    actions: {
+      tsumogiri: '摸切',
+      riichi: '立直',
+      tsumo: '自摸',
+      ron: '荣和',
+      pass: '跳过',
+      pon: '碰',
+      chi: '吃',
+      openKan: '明杠',
+      closedKan: '暗杠',
+      addedKan: '加杠',
+      advanceFinal: '终局',
+      advanceNext: '下一局',
+    },
+    statuses: {
+      idle: '请选择设置并开始游戏',
+      sending: '发送中…',
+      gameStarted: '对局已开始。',
+      noGame: '当前无对局',
+      gameEnded: '对局已结束',
+      awaitingHuman: '你的回合',
+      awaitingAI: 'AI 正在思考…',
+      roundSummaryPending: '请先查看结果并点击“下一局”',
+      roundSummaryPrompt: (label) => `请点击“${label}”查看结果`,
+      finished: '对局结束',
+    },
+    summaryReasons: {
+      tsumo: '自摸',
+      ron: '荣和',
+      abortive_draw_normal: '流局',
+    },
+    summary: {
+      defaultTitle: (reason) => `本局结果（${reason}）`,
+      finalTitle: '游戏结束',
+      winnersHeader: '和了详情',
+      yakuLabel: '役',
+      yakuman: (count) => `${count}倍役满`,
+      fanFu: (fan, fu) => `${fan}番 ${fu}符`,
+      dora: (dora, uraDora, includeUra = true) => {
+        if (includeUra && typeof uraDora === 'number') {
+          if (dora > 0 && uraDora > 0) {
+            return `宝牌：${dora}，里宝牌：${uraDora}`;
+          }
+          if (uraDora > 0) {
+            return `里宝牌：${uraDora}`;
+          }
+          return `宝牌：${dora}，里宝牌：0`;
+        }
+        return `宝牌：${dora}`;
+      },
+      doraTiles: (labels) => `宝牌指示牌：${labels.join(', ')}`,
+      uraDoraTiles: (labels) => `里宝牌指示牌：${labels.join(', ')}`,
+      winningTile: '和了牌',
+      winningTileFrom: (tile, rel, name) => `和了牌：${tile} ← ${rel}（${name}）`,
+      meta: (honba, kyotaku) => `本场：${honba} 立直棒：${kyotaku}`,
+      tableHeaders: ['位次', '座位', '名称', '点数', '增减'],
+      continue: '下一局',
+      endCta: '结束游戏',
+    },
+    advance: {
+      next: '下一局',
+      final: '结束游戏',
+    },
+    kanKinds: {
+      加槓: '加杠',
+      暗槓: '暗杠',
+    },
+  },
 };
 
 let currentLanguage = Languages.JA;
@@ -320,6 +443,8 @@ let pendingDiscardVisual = null;
 let pendingSummaryData = null;
 let summaryRevealRequested = false;
 let agentCache = [];
+let currentStatusKey = null;
+let currentStatusParams = {};
 
 humanNameInput.dataset.autoFilled = 'false';
 aiNameInput.dataset.autoFilled = 'false';
@@ -365,6 +490,10 @@ function getLocale(lang = currentLanguage) {
   return I18N[lang] || I18N.ja;
 }
 
+function getTileFaceLanguage(lang = currentLanguage) {
+  return lang === Languages.EN ? Languages.EN : Languages.JA;
+}
+
 function updateLanguageButtons() {
   const buttons = document.querySelectorAll(LANGUAGE_BUTTON_SELECTOR);
   buttons.forEach((btn) => {
@@ -397,6 +526,8 @@ function syncNoCallsControl(state) {
 
 function applyLocaleToStaticElements() {
   const locale = getLocale();
+  if (pageTitleEl) pageTitleEl.textContent = locale.title;
+  document.title = locale.title;
   if (handTitleEl) handTitleEl.textContent = locale.sections.hand;
   if (actionTitleEl) actionTitleEl.textContent = locale.sections.actions;
   if (scoreTitleEl) scoreTitleEl.textContent = locale.sections.score;
@@ -424,7 +555,9 @@ function applyLocaleToStaticElements() {
   if (summaryContinueBtn) {
     summaryContinueBtn.textContent = locale.summary.continue;
   }
-  if (!statusBarEl.textContent) {
+  if (currentStatusKey) {
+    setStatus(currentStatusKey, currentStatusParams);
+  } else if (!statusBarEl.textContent) {
     setStatus('idle');
   }
   document.documentElement.lang = locale.code;
@@ -461,6 +594,8 @@ function setStatus(key, params = {}) {
     statusBarEl.textContent = params.message || params.fallback || '';
     return;
   }
+  currentStatusKey = key;
+  currentStatusParams = params;
   const locale = getLocale();
   const template = locale.statuses[key];
   if (typeof template === 'function') {
@@ -819,7 +954,7 @@ function renderState(state, options = {}) {
 
 function getBoardSvg(state) {
   if (!state) return '';
-  if (currentLanguage === Languages.EN) {
+  if (getTileFaceLanguage() === Languages.EN) {
     return state.svgEnglish || state.svg || '';
   }
   return state.svgJapanese || state.svg || '';
@@ -1266,7 +1401,7 @@ function updateStatus(state) {
 }
 
 function tileLabel(tile, lang = currentLanguage) {
-  const locale = getLocale(lang);
+  const locale = getLocale(getTileFaceLanguage(lang));
   if (tile < 0) return '';
   if (tile === 34) return '5mr';
   if (tile === 35) return '5pr';
@@ -1279,7 +1414,7 @@ function tileLabel(tile, lang = currentLanguage) {
 
 function formatTileSequence(tiles) {
   if (!Array.isArray(tiles) || !tiles.length) return '';
-  const joiner = currentLanguage === Languages.JA ? '' : ' ';
+  const joiner = getTileFaceLanguage() === Languages.JA ? '' : ' ';
   return tiles.map((tile) => tileLabel(tile)).join(joiner);
 }
 
@@ -1296,6 +1431,25 @@ function translateWindName(wind) {
 function translateEventDescription(description) {
   if (currentLanguage === Languages.JA) return description;
   if (!description) return '';
+  if (currentLanguage === Languages.ZH_CN) {
+    if (description.startsWith('打 ')) {
+      return `打 ${description.slice(2)}`;
+    }
+    if (description.startsWith('カン ')) {
+      return `杠 ${description.slice(3)}`;
+    }
+    if (description === 'ツモ切り') return '摸切';
+    if (description === '立直宣言') return '立直宣言';
+    if (description === '自摸') return '自摸';
+    if (description.startsWith('ロン')) return description.replace('ロン', '荣和');
+    if (description.startsWith('ポン')) return description.replace('ポン', '碰');
+    if (description.startsWith('明槓')) return description.replace('明槓', '明杠');
+    if (description.startsWith('チー')) return description.replace('チー', '吃');
+    if (description === 'パス') return '跳过';
+    if (description === '進行') return '进行';
+    if (description.startsWith('アクション')) return description.replace('アクション', '行动');
+    return description;
+  }
   if (description.startsWith('打 ')) {
     return `Discard ${description.slice(2)}`;
   }

--- a/mahjax/ui/static/index.html
+++ b/mahjax/ui/static/index.html
@@ -8,10 +8,11 @@
 </head>
 <body>
   <header>
-    <h1>MahJax Human vs AI</h1>
+    <h1 data-i18n="index.title">MahJax Human vs AI</h1>
     <div id="languageToggle" class="language-toggle" role="group" aria-label="Language toggle">
       <button type="button" data-lang="ja" class="language-btn active">日本語</button>
       <button type="button" data-lang="en" class="language-btn">English</button>
+      <button type="button" data-lang="zh-CN" class="language-btn">简体中文</button>
     </div>
     <div id="controls">
       <label>


### PR DESCRIPTION
## Summary

- Add Simplified Chinese as a UI language option.
- Localize UI controls, status text, summary labels, scoreboard headers, and event descriptions.
- Add Simplified Chinese yaku names to the round summary payload and correct the Japanese robbing-a-kan label to 搶槓.
- Keep Chinese tile faces rendered with the Japanese tile-face language.

## Validation

- git diff --cached --check
- node --check mahjax/mahjax/ui/static/app.js
- python3 -m py_compile against the staged mahjax/ui/game_manager.py source
