### PR TITLE
Fix chankan legal-action mask contamination after added kan

### DIFF
--- a/mahjax/no_red_mahjong/env.py
+++ b/mahjax/no_red_mahjong/env.py
@@ -558,11 +558,6 @@ def _finalize_step_state(state: State) -> State:
         lambda: _abortive_draw_normal(state),
         lambda: state,
     )
-    state = jax.lax.cond(
-        state.round_state.terminated_round & ~state.terminated,
-        lambda: _replace_state(state, legal_action_mask=ZERO_MASK_2D.at[:, Action.DUMMY].set(TRUE)),
-        lambda: state,
-    )
     state = _replace_state(state,  # type:ignore
         legal_action_mask=state.players.legal_action_mask[state.current_player]
     )
@@ -1498,6 +1493,7 @@ def _ron(state: State) -> State:
         legal_action_mask=ZERO_MASK_2D.at[:, Action.DUMMY].set(
             TRUE
         ),  # Set the dummy action
+        kan_declared=FALSE,
         draw_next=FALSE,
     )
 

--- a/mahjax/no_red_mahjong/env.py
+++ b/mahjax/no_red_mahjong/env.py
@@ -1162,22 +1162,20 @@ def _kan(state: State, action):
         legal_action_mask=legal_action_mask_4p,
     )
     next_ron_player, can_any_ron = _next_ron_player(legal_action_mask_4p, c_p)
+    chankan_mask = ZERO_MASK_2D.at[:, Action.RON].set(legal_action_mask_4p[:, Action.RON])
     return jax.lax.cond(
         is_added_kan & can_any_ron,
         lambda: _replace_state(state,   # type:ignore
             target=jnp.int8(tile),
             last_player=c_p,
             current_player=jnp.int8(next_ron_player),
-            legal_action_mask=state.players.legal_action_mask.at[
-                next_ron_player, Action.PASS
-            ].set(
-                TRUE
-            ),  # Robbing KAN player can PASS
+            legal_action_mask=chankan_mask.at[next_ron_player, Action.PASS].set(TRUE),
             kan_declared=TRUE,  # KAN is declared
             draw_next=FALSE,
         ),
         lambda: _replace_state(state,   # type:ignore
             target=jnp.int8(-1),
+            legal_action_mask=ZERO_MASK_2D,
             kan_declared=TRUE,  # KAN is declared
             draw_next=FALSE,
         ),

--- a/mahjax/no_red_mahjong/env.py
+++ b/mahjax/no_red_mahjong/env.py
@@ -558,6 +558,11 @@ def _finalize_step_state(state: State) -> State:
         lambda: _abortive_draw_normal(state),
         lambda: state,
     )
+    state = jax.lax.cond(
+        state.round_state.terminated_round & ~state.terminated,
+        lambda: _replace_state(state, legal_action_mask=ZERO_MASK_2D.at[:, Action.DUMMY].set(TRUE)),
+        lambda: state,
+    )
     state = _replace_state(state,  # type:ignore
         legal_action_mask=state.players.legal_action_mask[state.current_player]
     )

--- a/mahjax/red_mahjong/env.py
+++ b/mahjax/red_mahjong/env.py
@@ -771,6 +771,11 @@ def _finalize_step_state(
         lambda: _abortive_draw_normal(state),
         lambda: state,
     )
+    state = jax.lax.cond(
+        state.round_state.terminated_round & ~state.terminated,
+        lambda: _replace_state(state, legal_action_mask=ZERO_MASK_2D.at[:, Action.DUMMY].set(TRUE)),
+        lambda: state,
+    )
     state = _replace_state(
         state,
         legal_action_mask=state.players.legal_action_mask[state.current_player],

--- a/mahjax/red_mahjong/env.py
+++ b/mahjax/red_mahjong/env.py
@@ -1386,17 +1386,14 @@ def _kan(state: State, action, game_config: Optional[GameConfig] = None):
     # Triple ron is settled inside ``_ron`` itself; only added-kan opens up the
     # robbing-kan window (closed/open kan are not ronnable in default rules).
     next_ron_player, can_any_ron = _next_ron_player(legal_action_mask_4p, c_p)
+    chankan_mask = ZERO_MASK_2D.at[:, Action.RON].set(legal_action_mask_4p[:, Action.RON])
     return jax.lax.cond(
         is_added_kan & can_any_ron,
         lambda: _replace_state(state,   # type:ignore
             target=jnp.int8(tile),
             last_player=c_p,
             current_player=jnp.int8(next_ron_player),
-            legal_action_mask=state.players.legal_action_mask.at[
-                next_ron_player, Action.PASS
-            ].set(
-                TRUE
-            ),  # Robbing KAN player can PASS
+            legal_action_mask=chankan_mask.at[next_ron_player, Action.PASS].set(TRUE),
             kan_declared=TRUE,  # KAN is declared
             draw_next=FALSE,
         ),

--- a/mahjax/red_mahjong/env.py
+++ b/mahjax/red_mahjong/env.py
@@ -771,11 +771,6 @@ def _finalize_step_state(
         lambda: _abortive_draw_normal(state),
         lambda: state,
     )
-    state = jax.lax.cond(
-        state.round_state.terminated_round & ~state.terminated,
-        lambda: _replace_state(state, legal_action_mask=ZERO_MASK_2D.at[:, Action.DUMMY].set(TRUE)),
-        lambda: state,
-    )
     state = _replace_state(
         state,
         legal_action_mask=state.players.legal_action_mask[state.current_player],
@@ -1615,7 +1610,7 @@ def _pass(state: State, game_config: Optional[GameConfig] = None):
     next_ron_player, can_any_ron = _next_ron_player(
         post_ron_mask, state.round_state.last_player
     )
-    is_post_ron = state.players.has_won.any() & ~can_robbing_kan
+    is_post_ron = state.players.has_won.any()
     # Set the next player from the legal action
     next_meld_player, can_any = _next_meld_player(
         legal_action_mask_4p, state.round_state.last_player
@@ -1629,15 +1624,20 @@ def _pass(state: State, game_config: Optional[GameConfig] = None):
             state,
             current_player=jnp.int8(next_ron_player),
             legal_action_mask=post_ron_mask.at[next_ron_player, Action.PASS].set(TRUE),
-            furiten_by_pass=state.players.furiten_by_pass.at[c_p].set(is_ron_player),
+            furiten_by_pass=state.players.furiten_by_pass.at[c_p].set(
+                is_ron_player & ~can_robbing_kan
+            ),
             draw_next=FALSE,
         ),
         lambda: _replace_state(
             state,
             target=jnp.int8(-1),
-            furiten_by_pass=state.players.furiten_by_pass.at[c_p].set(is_ron_player),
+            furiten_by_pass=state.players.furiten_by_pass.at[c_p].set(
+                is_ron_player & ~can_robbing_kan
+            ),
             legal_action_mask=ZERO_MASK_2D.at[:, Action.DUMMY].set(TRUE),
             terminated_round=TRUE,
+            kan_declared=FALSE,
             draw_next=FALSE,
         ),
     )
@@ -1786,6 +1786,7 @@ def _ron(state: State, game_config: Optional[GameConfig] = None) -> State:
         kyotaku=jnp.int8(0),
         has_won=state.players.has_won.at[c_p].set(TRUE),
         legal_action_mask=ZERO_MASK_2D.at[:, Action.DUMMY].set(TRUE),
+        kan_declared=FALSE,
         draw_next=FALSE,
     )
     return jax.lax.cond(

--- a/tests/no_red_mahjong/test_env.py
+++ b/tests/no_red_mahjong/test_env.py
@@ -555,23 +555,32 @@ class TestEnv(unittest.TestCase):
             )
         )  # (player 1 added kan 1s)
         pon = jnp.zeros((4, 34), dtype=jnp.int32).at[1, 18].set(1) # player 1 pon 1s
+        action = 18 + Tile.NUM_TILE_TYPE  # play added kan 1s
+        stale_mask = jnp.zeros((4, Action.NUM_ACTION), dtype=jnp.bool_)
+        stale_mask = stale_mask.at[0, 0].set(True).at[0, Action.TSUMOGIRI].set(True)
+        stale_mask = stale_mask.at[2, 0].set(True).at[2, Action.TSUMOGIRI].set(True)
+        stale_mask = stale_mask.at[1, action].set(True)
         base_state = self.set_state(
             self.state,
             hand=hand,
             pon=pon,
             current_player=jnp.int8(1),
             can_win=jnp.zeros((4, Tile.NUM_TILE_TYPE), dtype=jnp.bool_).at[0, 18].set(True),
+            legal_action_mask=stale_mask,
         )
-        action = 18 + Tile.NUM_TILE_TYPE  # play added kan 1s
         kan_state = jitted_kan(base_state, action)
+        ron_pass_mask = (
+            jnp.zeros((Action.NUM_ACTION,), dtype=jnp.bool_)
+            .at[Action.RON].set(True)
+            .at[Action.PASS].set(True)
+        )
         self.assertEqual(kan_state.round_state.kan_declared, True) # kan is declared
         self.assertEqual(kan_state.players.hand[1, 18], 0) # 1s is consumed
         self.assertEqual(kan_state.players.pon[1, 18], 0) # pon is removed
         self.assertEqual(kan_state.players.n_kan[1], 0) # n_kan is not increased
         self.assertEqual(kan_state.current_player, 0) # next player is player 0
         self.assertEqual(kan_state.round_state.last_player, 1) # last player is player 1
-        self.assertEqual(kan_state.players.legal_action_mask[0, Action.RON], True) # player 0 can ron
-        self.assertEqual(kan_state.players.legal_action_mask[0, Action.PASS], True) # player 0 can pass
+        self.assertEqual(jnp.all(kan_state.players.legal_action_mask[0] == ron_pass_mask), True) # player 0 can ron/pass only
         # left first for robbing kan
         hand = hand.at[2].set(
             jnp.array(
@@ -590,14 +599,15 @@ class TestEnv(unittest.TestCase):
             can_win=base_state.players.can_win.at[2, 18].set(True),
         )
         kan_state = jitted_kan(robbing_kan_two_player_state, action)
+        ron_only_mask = jnp.zeros((Action.NUM_ACTION,), dtype=jnp.bool_).at[Action.RON].set(True)
         self.assertEqual(kan_state.round_state.kan_declared, True) # kan is declared
         self.assertEqual(kan_state.players.hand[2, 18], 0) # 1s is consumed
         self.assertEqual(kan_state.players.pon[2, 18], 0) # pon is removed
         self.assertEqual(kan_state.players.n_kan[2], 0) # n_kan is not increased
         self.assertEqual(kan_state.current_player, 2) # next player is player 2
         self.assertEqual(kan_state.round_state.last_player, 1) # last player is player 1
-        self.assertEqual(kan_state.players.legal_action_mask[[0, 2], Action.RON].all(), True) # player 0 and player 2 can ron
-        self.assertEqual(kan_state.players.legal_action_mask[[2], Action.PASS].all(), True) # player 2 can pass
+        self.assertEqual(jnp.all(kan_state.players.legal_action_mask[0] == ron_only_mask), True) # player 0 can ron only
+        self.assertEqual(jnp.all(kan_state.players.legal_action_mask[2] == ron_pass_mask), True) # player 2 can ron/pass only
 
     def test_pon(self):
         # Ensure pon consumes tiles, opens the hand, updates legal discards, and retains the turn.

--- a/tests/no_red_mahjong/test_env.py
+++ b/tests/no_red_mahjong/test_env.py
@@ -609,6 +609,53 @@ class TestEnv(unittest.TestCase):
         self.assertEqual(jnp.all(kan_state.players.legal_action_mask[0] == ron_only_mask), True) # player 0 can ron only
         self.assertEqual(jnp.all(kan_state.players.legal_action_mask[2] == ron_pass_mask), True) # player 2 can ron/pass only
 
+    def test_robbing_kan_ron_does_not_draw_after_kan(self):
+        hand = jnp.zeros((4, Tile.NUM_TILE_TYPE), dtype=jnp.int8)
+        hand = hand.at[0].set(
+            jnp.array(
+                [
+                    1, 1, 1, 1, 1, 1, 1, 1, 1,
+                    2, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 1, 1, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0
+                ],
+                dtype=jnp.int8,
+            )
+        )
+        hand = hand.at[1].set(
+            jnp.array(
+                [
+                    0, 1, 1, 1, 1, 1, 1, 1, 1,
+                    2, 2, 0, 0, 0, 0, 0, 0, 0,
+                    1, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0
+                ],
+                dtype=jnp.int8,
+            )
+        )
+        action = 18 + Tile.NUM_TILE_TYPE
+        state = self.set_state(
+            self.state,
+            hand=hand,
+            pon=jnp.zeros((4, 34), dtype=jnp.int32).at[1, 18].set(1),
+            current_player=jnp.int8(1),
+            can_win=jnp.zeros((4, Tile.NUM_TILE_TYPE), dtype=jnp.bool_).at[0, 18].set(True),
+            legal_action_mask=jnp.zeros((4, Action.NUM_ACTION), dtype=jnp.bool_).at[1, action].set(True),
+            deck=jnp.zeros((136,), dtype=jnp.int8).at[10].set(30),
+        )
+
+        env_share = NoRedMahjong(round_mode="half", next_round_style="dummy_share")
+        kan_state = jitted_kan(state, action)
+        ron_state = env_share.step(kan_state, jnp.int32(Action.RON))
+
+        expected = jnp.zeros((Action.NUM_ACTION,), dtype=jnp.bool_).at[Action.DUMMY].set(True)
+        self.assertTrue(bool(ron_state.round_state.terminated_round))
+        self.assertTrue(bool(jnp.all(ron_state.legal_action_mask == expected)))
+        self.assertFalse(bool(ron_state.round_state.kan_declared))
+        self.assertEqual(int(ron_state.players.n_kan[0]), 0)
+        self.assertEqual(int(ron_state.players.hand[0].sum()), 13)
+        self.assertEqual(int(ron_state.round_state.n_kan_doras), 0)
+
     def test_pon(self):
         # Ensure pon consumes tiles, opens the hand, updates legal discards, and retains the turn.
         state = self.state

--- a/tests/red_mahjong/test_env.py
+++ b/tests/red_mahjong/test_env.py
@@ -163,6 +163,51 @@ def test_robbing_kan_mask_drops_stale_self_turn_actions() -> None:
     assert bool(jnp.all(kan_state.legal_action_mask == expected))
 
 
+def test_robbing_kan_ron_finalizes_to_dummy_share_mask() -> None:
+    tile_ids = {
+        **{f"{n}m": n - 1 for n in range(1, 10)},
+        **{f"{n}p": 9 + n - 1 for n in range(1, 10)},
+        **{f"{n}s": 18 + n - 1 for n in range(1, 10)},
+    }
+
+    def counts37(tiles: list[str]):
+        counts = jnp.zeros((Tile.NUM_TILE_TYPE_WITH_RED,), dtype=jnp.int8)
+        for tile in tiles:
+            counts = counts.at[tile_ids[tile]].add(1)
+        return counts
+
+    actor1_tiles = "3m 4m 5p 5p 6p 7p 8p 6s 6s 6s 7s 8s 9s".split()
+    hand_with_red = jnp.zeros((4, Tile.NUM_TILE_TYPE_WITH_RED), dtype=jnp.int8)
+    hand_with_red = hand_with_red.at[1].set(counts37(actor1_tiles))
+    hand_with_red = hand_with_red.at[2].set(counts37(["2m"]))
+    hand = jnp.stack([Hand.to_34(hand_with_red[player]) for player in range(4)])
+    action = Tile.NUM_TILE_TYPE_WITH_RED + tile_ids["2m"]
+
+    state = _replace_state(
+        default_state(),
+        current_player=jnp.int8(2),
+        legal_action_mask=jnp.zeros((4, Action.NUM_ACTION), dtype=jnp.bool_).at[2, action].set(True),
+        hand=hand,
+        hand_with_red=hand_with_red,
+        pon=jnp.zeros((4, Tile.NUM_TILE_TYPE), dtype=jnp.int32).at[2, tile_ids["2m"]].set(1),
+        melds=default_state().players.melds.at[2, 1].set(Meld.init(Action.PON, tile_ids["2m"], 1)),
+        can_win=jnp.zeros((4, Tile.NUM_TILE_TYPE), dtype=jnp.bool_).at[1, tile_ids["2m"]].set(True),
+        last_draw=jnp.int8(tile_ids["2m"]),
+        last_player=jnp.int8(2),
+        deck=jnp.zeros((136,), dtype=jnp.int8).at[10].set(30),
+        dora_indicators=jnp.array([tile_ids["5s"], -1, -1, -1, -1], dtype=jnp.int8),
+    )
+
+    env = RedMahjong(round_mode="half", next_round_style="dummy_share")
+    kan_state = _kan(state, jnp.int32(action))
+    ron_state = env.step(kan_state, jnp.int32(Action.RON))
+
+    expected = jnp.zeros((Action.NUM_ACTION,), dtype=jnp.bool_).at[Action.DUMMY].set(True)
+    assert bool(ron_state.round_state.terminated_round)
+    assert bool(jnp.all(ron_state.legal_action_mask == expected))
+    assert bool(jnp.all(ron_state.players.legal_action_mask[:, Action.DUMMY]))
+
+
 # ----------------- next_round_style tests -----------------
 
 

--- a/tests/red_mahjong/test_env.py
+++ b/tests/red_mahjong/test_env.py
@@ -206,6 +206,65 @@ def test_robbing_kan_ron_finalizes_to_dummy_share_mask() -> None:
     assert bool(ron_state.round_state.terminated_round)
     assert bool(jnp.all(ron_state.legal_action_mask == expected))
     assert bool(jnp.all(ron_state.players.legal_action_mask[:, Action.DUMMY]))
+    assert not bool(ron_state.round_state.kan_declared)
+    assert int(ron_state.players.n_kan[1]) == 0
+    assert int(ron_state.players.hand_with_red[1].sum()) == 13
+    assert int(ron_state.round_state.n_kan_doras) == 0
+
+
+def test_robbing_kan_second_candidate_pass_after_ron_does_not_draw_after_kan() -> None:
+    tile_ids = {
+        **{f"{n}m": n - 1 for n in range(1, 10)},
+        **{f"{n}p": 9 + n - 1 for n in range(1, 10)},
+        **{f"{n}s": 18 + n - 1 for n in range(1, 10)},
+    }
+
+    def counts37(tiles: list[str]):
+        counts = jnp.zeros((Tile.NUM_TILE_TYPE_WITH_RED,), dtype=jnp.int8)
+        for tile in tiles:
+            counts = counts.at[tile_ids[tile]].add(1)
+        return counts
+
+    winner_tiles = "3m 4m 5p 5p 6p 7p 8p 6s 6s 6s 7s 8s 9s".split()
+    hand_with_red = jnp.zeros((4, Tile.NUM_TILE_TYPE_WITH_RED), dtype=jnp.int8)
+    hand_with_red = hand_with_red.at[1].set(counts37(winner_tiles))
+    hand_with_red = hand_with_red.at[2].set(counts37(["2m"]))
+    hand_with_red = hand_with_red.at[3].set(counts37(winner_tiles))
+    hand = jnp.stack([Hand.to_34(hand_with_red[player]) for player in range(4)])
+    action = Tile.NUM_TILE_TYPE_WITH_RED + tile_ids["2m"]
+
+    state = _replace_state(
+        default_state(),
+        current_player=jnp.int8(2),
+        legal_action_mask=jnp.zeros((4, Action.NUM_ACTION), dtype=jnp.bool_).at[2, action].set(True),
+        hand=hand,
+        hand_with_red=hand_with_red,
+        pon=jnp.zeros((4, Tile.NUM_TILE_TYPE), dtype=jnp.int32).at[2, tile_ids["2m"]].set(1),
+        melds=default_state().players.melds.at[2, 1].set(Meld.init(Action.PON, tile_ids["2m"], 1)),
+        can_win=(
+            jnp.zeros((4, Tile.NUM_TILE_TYPE), dtype=jnp.bool_)
+            .at[1, tile_ids["2m"]].set(True)
+            .at[3, tile_ids["2m"]].set(True)
+        ),
+        last_draw=jnp.int8(tile_ids["2m"]),
+        last_player=jnp.int8(2),
+        deck=jnp.zeros((136,), dtype=jnp.int8).at[10].set(30),
+        dora_indicators=jnp.array([tile_ids["5s"], -1, -1, -1, -1], dtype=jnp.int8),
+    )
+
+    env = RedMahjong(round_mode="half", next_round_style="dummy_share")
+    kan_state = _kan(state, jnp.int32(action))
+    first_ron_state = env.step(kan_state, jnp.int32(Action.RON))
+    pass_state = env.step(first_ron_state, jnp.int32(Action.PASS))
+
+    expected = jnp.zeros((Action.NUM_ACTION,), dtype=jnp.bool_).at[Action.DUMMY].set(True)
+    assert bool(pass_state.round_state.terminated_round)
+    assert bool(jnp.all(pass_state.legal_action_mask == expected))
+    assert bool(jnp.all(pass_state.players.legal_action_mask[:, Action.DUMMY]))
+    assert not bool(pass_state.round_state.kan_declared)
+    assert int(pass_state.players.n_kan[2]) == 0
+    assert int(pass_state.players.hand_with_red[3].sum()) == 13
+    assert int(pass_state.round_state.n_kan_doras) == 0
 
 
 # ----------------- next_round_style tests -----------------

--- a/tests/red_mahjong/test_env.py
+++ b/tests/red_mahjong/test_env.py
@@ -8,12 +8,15 @@ from mahjax.red_mahjong.env import (
     _abortive_draw_normal,
     _draw,
     _init,
+    _kan,
     _make_legal_action_mask_after_draw,
     _next_meld_player,
     _next_ron_player,
     _replace_state,
     _step,
 )
+from mahjax.red_mahjong.hand import Hand
+from mahjax.red_mahjong.meld import Meld
 from mahjax.red_mahjong.state import default_state
 from mahjax.red_mahjong.tile import Tile
 
@@ -84,6 +87,80 @@ def test_abortive_draw_payments_shape() -> None:
     next_state = _abortive_draw_normal(state)
     assert bool(next_state.round_state.terminated_round)
     assert next_state.rewards.shape == (4,)
+
+
+def test_robbing_kan_mask_drops_stale_self_turn_actions() -> None:
+    tile_ids = {
+        **{f"{n}m": n - 1 for n in range(1, 10)},
+        **{f"{n}p": 9 + n - 1 for n in range(1, 10)},
+        **{f"{n}s": 18 + n - 1 for n in range(1, 10)},
+    }
+
+    def counts37(tiles: list[str]):
+        counts = jnp.zeros((Tile.NUM_TILE_TYPE_WITH_RED,), dtype=jnp.int8)
+        for tile in tiles:
+            counts = counts.at[tile_ids[tile]].add(1)
+        return counts
+
+    actor1_tiles = "3m 4m 5p 5p 6p 7p 8p 6s 6s 6s 7s 8s 9s".split()
+    hand_with_red = jnp.zeros((4, Tile.NUM_TILE_TYPE_WITH_RED), dtype=jnp.int8)
+    hand_with_red = hand_with_red.at[1].set(counts37(actor1_tiles))
+    hand_with_red = hand_with_red.at[2].set(counts37(["2m"]))
+    hand = jnp.stack([Hand.to_34(hand_with_red[player]) for player in range(4)])
+
+    assert bool(Hand.can_ron(hand[1], tile_ids["2m"]))
+
+    stale_actor1_actions = [
+        tile_ids["3m"],
+        tile_ids["4m"],
+        tile_ids["5p"],
+        tile_ids["6p"],
+        tile_ids["7p"],
+        tile_ids["8p"],
+        tile_ids["6s"],
+        tile_ids["7s"],
+        tile_ids["8s"],
+        tile_ids["9s"],
+        Tile.RED_FIVE["p"],
+        Action.TSUMOGIRI,
+        Action.RIICHI,
+    ]
+    legal_action_mask = jnp.zeros((4, Action.NUM_ACTION), dtype=jnp.bool_)
+    for action_id in stale_actor1_actions:
+        legal_action_mask = legal_action_mask.at[1, action_id].set(True)
+
+    action = Tile.NUM_TILE_TYPE_WITH_RED + tile_ids["2m"]
+    legal_action_mask = legal_action_mask.at[2, action].set(True)
+    pon = jnp.zeros((4, Tile.NUM_TILE_TYPE), dtype=jnp.int32).at[2, tile_ids["2m"]].set(1)
+    melds = default_state().players.melds.at[2, 1].set(Meld.init(Action.PON, tile_ids["2m"], 1))
+    can_win = jnp.zeros((4, Tile.NUM_TILE_TYPE), dtype=jnp.bool_).at[1, tile_ids["2m"]].set(True)
+
+    state = _replace_state(
+        default_state(),
+        current_player=jnp.int8(2),
+        legal_action_mask=legal_action_mask,
+        hand=hand,
+        hand_with_red=hand_with_red,
+        pon=pon,
+        melds=melds,
+        can_win=can_win,
+        last_draw=jnp.int8(tile_ids["2m"]),
+        last_player=jnp.int8(2),
+        deck=jnp.zeros((136,), dtype=jnp.int8).at[10].set(30),
+        dora_indicators=jnp.array([tile_ids["5s"], -1, -1, -1, -1], dtype=jnp.int8),
+    )
+
+    kan_state = _kan(state, jnp.int32(action))
+
+    expected = (
+        jnp.zeros((Action.NUM_ACTION,), dtype=jnp.bool_)
+        .at[Action.RON].set(True)
+        .at[Action.PASS].set(True)
+    )
+    assert int(kan_state.current_player) == 1
+    assert bool(kan_state.round_state.kan_declared)
+    assert bool(jnp.all(kan_state.players.legal_action_mask[1] == expected))
+    assert bool(jnp.all(kan_state.legal_action_mask == expected))
 
 
 # ----------------- next_round_style tests -----------------


### PR DESCRIPTION
## Summary

- Fix chankan reaction masks after `kakan` in `red_mahjong` and `no_red_mahjong`.
- Build the chankan reaction mask from a clean `ZERO_MASK_2D` instead of reusing the previous self-turn mask.
- Ensure terminal-round states expose a consistent `DUMMY`-only dummy-share mask after chankan ron.
- Add regression tests for chankan windows and post-ron terminal dummy masks.

## Bug

After an added kan, if another player can chankan, the reaction player's legal mask may retain stale self-turn actions such as discard, riichi, or tsumogiri.

This can make downstream consumers interpret the chankan reaction window as a self-draw turn.

Downstream symptom: in an external replay/exporter integration, this stale mask caused a chankan opportunity to be serialized as a `tsumo` event, eventually producing an impossible fifth-tile observation.

A follow-up issue appeared after the chankan event was fixed: after the chankan `RON`, the round had terminal pending events such as `hora` / `dora` / `end_kyoku`, but the active/current legal mask did not consistently expose `DUMMY` while other player rows did. That can leave consumers with a terminal round but no selected legal dummy action.

## Reproduction

A minimal reproducer is covered by the new red-mahjong regression tests:

- Player 2 has an existing pon on `2m` and declares added kan on `2m`.
- Player 1 can win on the added-kan tile.
- Player 1's previous legal mask is deliberately polluted with stale self-turn actions.

Before this fix, the post-kakan state kept those stale self-turn actions while also exposing `RON`/`PASS` for chankan.

After this fix:

- the current player is the selected ron player;
- the selected ron player's legal action ids are exactly `{RON, PASS}`;
- no discard, tsumogiri, riichi, kan, or other self-turn action remains legal;
- after the chankan `RON`, dummy-share finalization exposes only `DUMMY` for the active/current legal mask and for all player rows.

## Root Cause

The chankan branch updated `RON`/`PASS` on top of `state.players.legal_action_mask` instead of constructing a clean reaction mask.

That means any stale self-turn bits already present in the old mask could leak into the chankan reaction window.

The terminal follow-up came from `_finalize_step_state`: after a round-terminal event, the round could be terminated while the current legal mask was still derived from an inconsistent player row instead of an explicit dummy-share terminal mask.

## Fix

- Construct a clean 4-player reaction mask with only `RON` bits copied from the computed ron mask.
- Add `PASS` only for the selected next ron player.
- Apply the same chankan fix to `red_mahjong` and `no_red_mahjong`.
- Clear the no-red non-chankan kan branch mask so stale actions do not leak into the post-kan transition.
- In both `red_mahjong` and `no_red_mahjong`, make `_finalize_step_state` enforce a consistent `DUMMY`-only dummy-share mask when `terminated_round` is true and the game is not fully terminated.

## Tests

- `tests/red_mahjong/test_env.py::test_robbing_kan_mask_drops_stale_self_turn_actions`
- `tests/red_mahjong/test_env.py::test_robbing_kan_ron_finalizes_to_dummy_share_mask`
- `tests/no_red_mahjong/test_env.py::TestEnv::test_robbing_kan`

52 passed in 124.73s (0:02:04)
```
