### PR TITLE
fix(examples): jax.tree_map -> jax.tree.map

### DIFF
--- a/examples/bc.py
+++ b/examples/bc.py
@@ -117,7 +117,7 @@ def visualize_game(cfg, train_state):
         if state.current_player == agent_seat:
             obs = env.observe(state)
             # Add batch dim
-            obs_batched = jax.tree_map(lambda x: x[None, ...], obs)
+            obs_batched = jax.tree.map(lambda x: x[None, ...], obs)
             mask_batched = state.legal_action_mask[None, ...]
             action = policy_fn(obs_batched, mask_batched, k_act)[0]
         else:
@@ -173,7 +173,7 @@ def main():
     rng, init_rng = jax.random.split(rng)
     
     # Dummy obs for init
-    dummy_obs = jax.tree_map(lambda x: x[0:1], obs_data)
+    dummy_obs = jax.tree.map(lambda x: x[0:1], obs_data)
     train_state = create_train_state(init_rng, model, dummy_obs, cfg.lr)
     
     # 4. Training Loop
@@ -189,7 +189,7 @@ def main():
         for i in pbar:
             batch_idx = train_indices[i*cfg.batch_size : (i+1)*cfg.batch_size]
             batch = {
-                'obs': jax.tree_map(lambda x: x[batch_idx], obs_data),
+                'obs': jax.tree.map(lambda x: x[batch_idx], obs_data),
                 'act': act_data[batch_idx],
                 'mask': mask_data[batch_idx]
             }
@@ -205,7 +205,7 @@ def main():
             idx_end = min((i + 1) * cfg.batch_size, len(val_indices))
             batch_idx = val_indices[idx_start:idx_end]
             batch = {
-                'obs': jax.tree_map(lambda x: x[batch_idx], obs_data),
+                'obs': jax.tree.map(lambda x: x[batch_idx], obs_data),
                 'act': act_data[batch_idx],
                 'mask': mask_data[batch_idx]
             }

--- a/examples/collect_offline_data.py
+++ b/examples/collect_offline_data.py
@@ -145,7 +145,7 @@ def main():
         state, (obs_seq, act_seq, mask_seq, rew_seq, done_seq, cp_seq) = jit_rollout(state, keys)
 
         # CPU Transfer
-        obs_cpu = jax.tree_map(np.array, obs_seq)
+        obs_cpu = jax.tree.map(np.array, obs_seq)
         act_cpu = np.array(act_seq)
         mask_cpu = np.array(mask_seq)
         rew_cpu = np.array(rew_seq)
@@ -165,7 +165,7 @@ def main():
         returns_chunk = returns_chunk / cfg.max_reward
 
         # Flatten & Store
-        flat_obs = jax.tree_map(lambda x: x.reshape(-1, *x.shape[2:]), obs_cpu)
+        flat_obs = jax.tree.map(lambda x: x.reshape(-1, *x.shape[2:]), obs_cpu)
         data_obs.append(flat_obs)
         data_act.append(act_cpu.flatten())
         data_mask.append(mask_cpu.reshape(-1, mask_cpu.shape[-1]))


### PR DESCRIPTION
jax.tree_map was deprecated in JAX 0.4.25 and removed in recent releases; examples crash on import with current JAX. jax.tree.map is available since 0.4.25, so this stays compatible with older versions too.