### PR TITLE
perf(shanten): remove lax.cond in discard paths to stop per-lane CACHE materialization

### DIFF
--- a/mahjax/no_red_mahjong/shanten.py
+++ b/mahjax/no_red_mahjong/shanten.py
@@ -35,30 +35,27 @@ class Shanten:
     # See the link below for the algorithm details.
     # https://github.com/sotetsuk/pgx/pull/123
     CACHE = load_shanten_cache()
+    # Flatten once at load time: reshaping inside traced code makes XLA
+    # materialize a fresh ~70MiB copy of the table per scan/vmap instance.
+    CACHE_FLAT = CACHE.reshape(-1)
 
     @staticmethod
     def discard(hand: Array) -> Array:
-        # i to int32, align the dtype of both branches of cond
-        def f(i):
-            i = jnp.int32(i)
-            return jax.lax.cond(
-                hand[i] == 0,
-                lambda: jnp.int32(6),
-                lambda: Shanten.number(hand.at[i].set(hand[i] - 1)),
-            )
-
-        return jax.vmap(f)(jnp.arange(34, dtype=jnp.int32))
+        # Cond-free formulation: wrapping Shanten.number in lax.cond under the
+        # 34-way vmap makes XLA materialize a copy of the ~70MiB CACHE per lane
+        # (74GiB temp at batch 32); computing all candidates and masking with
+        # where compiles to plain gathers with ~0 temp memory.
+        eye = jnp.eye(34, dtype=hand.dtype)
+        cand = jnp.maximum(hand[None, :] - eye, 0)  # (34, 34)
+        res = jax.vmap(Shanten.number)(cand)  # (34,)
+        return jnp.where(hand > 0, res, jnp.int32(6))
 
     def detailed_discard(hand: Array) -> Array:
-        def f(i):
-            i = jnp.int32(i)
-            return jax.lax.cond(
-                hand[i] == 0,
-                lambda: jnp.array([6, 6, 6]),
-                lambda: Shanten.detailed_number(hand.at[i].set(hand[i] - 1)),
-            )
-
-        return jax.vmap(f)(jnp.arange(34, dtype=jnp.int32))  # (34, 3)
+        # See discard() for why this avoids lax.cond.
+        eye = jnp.eye(34, dtype=hand.dtype)
+        cand = jnp.maximum(hand[None, :] - eye, 0)  # (34, 34)
+        res = jax.vmap(Shanten.detailed_number)(cand)  # (34, 3)
+        return jnp.where((hand > 0)[:, None], res, jnp.int32(6))
 
     @staticmethod
     def number(hand: Array) -> Array:
@@ -124,7 +121,7 @@ class Shanten:
 
         def gather_elem(c, idx):
             lin = c * J + idx
-            return jnp.take(CACHE.reshape(-1), lin)
+            return jnp.take(Shanten.CACHE_FLAT, lin)
 
         # 4 variants simultaneously calculate
         base_costs = gather_elem(code, jnp.full((4,), 4, dtype=jnp.int32))  # (4,)

--- a/mahjax/red_mahjong/shanten.py
+++ b/mahjax/red_mahjong/shanten.py
@@ -35,30 +35,26 @@ class Shanten:
     # See the link below for the algorithm details.
     # https://github.com/sotetsuk/pgx/pull/123
     CACHE = load_shanten_cache()
+    # Flatten once at load time to avoid per-instance materialization in XLA.
+    CACHE_FLAT = CACHE.reshape(-1)
 
     @staticmethod
     def discard(hand: Array) -> Array:
-        # i to int32, align the dtype of both branches of cond
-        def f(i):
-            i = jnp.int32(i)
-            return jax.lax.cond(
-                hand[i] == 0,
-                lambda: jnp.int32(6),
-                lambda: Shanten.number(hand.at[i].set(hand[i] - 1)),
-            )
-
-        return jax.vmap(f)(jnp.arange(34, dtype=jnp.int32))
+        # Cond-free formulation: wrapping Shanten.number in lax.cond under the
+        # 34-way vmap makes XLA materialize a copy of the ~70MiB CACHE per lane
+        # (74GiB temp at batch 32); computing all candidates and masking with
+        # where compiles to plain gathers with ~0 temp memory.
+        eye = jnp.eye(34, dtype=hand.dtype)
+        cand = jnp.maximum(hand[None, :] - eye, 0)  # (34, 34)
+        res = jax.vmap(Shanten.number)(cand)  # (34,)
+        return jnp.where(hand > 0, res, jnp.int32(6))
 
     def detailed_discard(hand: Array) -> Array:
-        def f(i):
-            i = jnp.int32(i)
-            return jax.lax.cond(
-                hand[i] == 0,
-                lambda: jnp.array([6, 6, 6]),
-                lambda: Shanten.detailed_number(hand.at[i].set(hand[i] - 1)),
-            )
-
-        return jax.vmap(f)(jnp.arange(34, dtype=jnp.int32))  # (34, 3)
+        # See discard() for why this avoids lax.cond.
+        eye = jnp.eye(34, dtype=hand.dtype)
+        cand = jnp.maximum(hand[None, :] - eye, 0)  # (34, 34)
+        res = jax.vmap(Shanten.detailed_number)(cand)  # (34, 3)
+        return jnp.where((hand > 0)[:, None], res, jnp.int32(6))
 
     @staticmethod
     def number(hand: Array) -> Array:
@@ -124,7 +120,7 @@ class Shanten:
 
         def gather_elem(c, idx):
             lin = c * J + idx
-            return jnp.take(CACHE.reshape(-1), lin)
+            return jnp.take(Shanten.CACHE_FLAT, lin)
 
         # 4 variants simultaneously calculate
         base_costs = gather_elem(code, jnp.full((4,), 4, dtype=jnp.int32))  # (4,)

--- a/tests/no_red_mahjong/test_shanten_discard.py
+++ b/tests/no_red_mahjong/test_shanten_discard.py
@@ -1,0 +1,40 @@
+import unittest
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from mahjax.no_red_mahjong.shanten import Shanten
+
+jit_discard = jax.jit(Shanten.discard)
+jit_detailed_discard = jax.jit(Shanten.detailed_discard)
+jit_number = jax.jit(Shanten.number)
+jit_detailed_number = jax.jit(Shanten.detailed_number)
+
+
+class TestShantenDiscard(unittest.TestCase):
+    """discard/detailed_discard must equal number/detailed_number applied to
+    each one-tile-removed hand (and 6 for tiles not in hand)."""
+
+    def test_discard_matches_number(self):
+        rng = np.random.default_rng(0)
+        for _ in range(50):
+            tiles = rng.choice(136, size=14, replace=False)
+            hand = np.bincount(tiles // 4, minlength=34).astype(np.int32)
+            hand_j = jnp.asarray(hand)
+            got = np.asarray(jit_discard(hand_j))
+            got_detail = np.asarray(jit_detailed_discard(hand_j))
+            for i in range(34):
+                if hand[i] == 0:
+                    self.assertEqual(got[i], 6)
+                    self.assertTrue((got_detail[i] == 6).all())
+                else:
+                    reduced = hand_j.at[i].add(-1)
+                    self.assertEqual(got[i], int(jit_number(reduced)))
+                    np.testing.assert_array_equal(
+                        got_detail[i], np.asarray(jit_detailed_number(reduced))
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/red_mahjong/test_shanten_discard.py
+++ b/tests/red_mahjong/test_shanten_discard.py
@@ -1,0 +1,40 @@
+import unittest
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from mahjax.red_mahjong.shanten import Shanten
+
+jit_discard = jax.jit(Shanten.discard)
+jit_detailed_discard = jax.jit(Shanten.detailed_discard)
+jit_number = jax.jit(Shanten.number)
+jit_detailed_number = jax.jit(Shanten.detailed_number)
+
+
+class TestShantenDiscard(unittest.TestCase):
+    """discard/detailed_discard must equal number/detailed_number applied to
+    each one-tile-removed hand (and 6 for tiles not in hand)."""
+
+    def test_discard_matches_number(self):
+        rng = np.random.default_rng(0)
+        for _ in range(50):
+            tiles = rng.choice(136, size=14, replace=False)
+            hand = np.bincount(tiles // 4, minlength=34).astype(np.int32)
+            hand_j = jnp.asarray(hand)
+            got = np.asarray(jit_discard(hand_j))
+            got_detail = np.asarray(jit_detailed_discard(hand_j))
+            for i in range(34):
+                if hand[i] == 0:
+                    self.assertEqual(got[i], 6)
+                    self.assertTrue((got_detail[i] == 6).all())
+                else:
+                    reduced = hand_j.at[i].add(-1)
+                    self.assertEqual(got[i], int(jit_number(reduced)))
+                    np.testing.assert_array_equal(
+                        got_detail[i], np.asarray(jit_detailed_number(reduced))
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Under a 34-way vmap, lax.cond made XLA materialize the ~70MiB shanten CACHE
per lane (74GiB temp at batch 32; the old README's 2.3TiB warning at
num_envs=1024 has the same root cause). Pre-flatten CACHE_FLAT and compute
both branches unconditionally instead.