### PR TITLE
fix(examples): guard bc.py top-level CLI parsing against importers' flags

### DIFF
--- a/examples/bc.py
+++ b/examples/bc.py
@@ -46,7 +46,16 @@ class TrainConfig:
 
 # cli
 conf_dict = OmegaConf.from_cli()
-cfg = TrainConfig(**conf_dict)
+if __name__ == "__main__":
+    cfg = TrainConfig(**conf_dict)
+else:
+    # Imported (e.g. `from bc import visualize_game` in ppo_with_reg.py): the
+    # CLI belongs to the importing script, whose flags (num_envs, num_steps,
+    # ...) are not TrainConfig fields and would raise TypeError here. Keep
+    # only the keys BC recognizes so env_name still selects the right
+    # network for the importer.
+    _bc_keys = {k: v for k, v in conf_dict.items() if k in TrainConfig.__dataclass_fields__}
+    cfg = TrainConfig(**_bc_keys)
 NETWORK_CLS = get_network_cls(cfg.env_name)
 
 # --- Train State ---


### PR DESCRIPTION
bc.py parses OmegaConf.from_cli() at module import time, but ppo_with_reg.py does 'from bc import visualize_game', so running PPO with its own flags (num_envs=..., num_steps=...) crashes with 'TrainConfig.__init__() got an unexpected keyword argument'. When imported, keep only the keys TrainConfig recognizes (env_name still selects the correct network for the importer).