### PR TITLE
fix: forbid CHI that leaves no legal discard after kuikae (#61)

### DIFF
--- a/mahjax/no_red_mahjong/env.py
+++ b/mahjax/no_red_mahjong/env.py
@@ -902,12 +902,42 @@ def _make_legal_action_mask_after_discard(
     return mask
 
 
+def _discard_tile_mask_after_chi(hand_after_chi: Array, target: Array, action: Array) -> Array:
+    """
+    Tile-type discard mask after CHI with kuikae (swap-calling) prohibited.
+    - ``hand_after_chi`` is the caller's hand after the CHI meld is removed.
+    - Prohibit the swap-calling tile type (if any) and the called tile type.
+    """
+    prohibitive_tile_type = Meld.prohibitive_tile_type_after_chi(action, target)
+    tile_mask = hand_after_chi > 0
+    tile_mask = jax.lax.cond(
+        prohibitive_tile_type >= 0,
+        lambda: tile_mask.at[prohibitive_tile_type].set(FALSE),
+        lambda: tile_mask,
+    )
+    tile_mask = tile_mask.at[target].set(FALSE)
+    return tile_mask
+
+
 def _mask_for_chi(hand: Array, tile: Array) -> Array:
     """
     - Check if the player can play CHI with the target tile
+    - A CHI is legal only when at least one discard remains after the kuikae
+      restrictions; otherwise it would produce an active state with an all-false
+      legal action mask (see issue #61).
     """
-    chi_results = jax.vmap(Hand.can_chi, in_axes=(None, None, 0))(
-        hand, tile, jnp.arange(Action.CHI_L, Action.CHI_R + 1)
+
+    def _can_chi_and_discard(action: Array) -> Array:
+        can_chi = Hand.can_chi(hand, tile, action)
+        has_discard = jax.lax.cond(
+            can_chi,
+            lambda: _discard_tile_mask_after_chi(Hand.chi(hand, tile, action), tile, action).any(),
+            lambda: FALSE,
+        )
+        return can_chi & has_discard
+
+    chi_results = jax.vmap(_can_chi_and_discard)(
+        jnp.arange(Action.CHI_L, Action.CHI_R + 1)
     )
     legal_action_mask = ZERO_MASK_1D.at[Action.CHI_L : Action.CHI_R + 1].set(
         chi_results
@@ -1344,17 +1374,7 @@ def _make_legal_action_mask_after_chi(
     - Prohibit eating changes (喰いかえ)
     - If the prohibited tile is 5, also prohibit red tiles
     """
-    prohibitive_tile_type = Meld.prohibitive_tile_type_after_chi(
-        action, target
-    )  # Prohibit Swap-Calling: [1]23 -> 4 is prohibited
-    # Create player's mask efficiently
-    tile_mask = hand[c_p] > 0
-    # Apply prohibitive tile restriction
-    tile_mask = tile_mask.at[prohibitive_tile_type].set(
-        jnp.logical_and(tile_mask[prohibitive_tile_type], prohibitive_tile_type == -1)
-    )
-    # Prohibit the target tile to be discarded
-    tile_mask = tile_mask.at[target].set(FALSE)
+    tile_mask = _discard_tile_mask_after_chi(hand[c_p], target, action)
     player_mask = ZERO_MASK_1D.at[: Tile.NUM_TILE_TYPE].set(tile_mask)
     # Build the legal action mask for the player
     legal_action_mask_4p = ZERO_MASK_2D.at[c_p].set(player_mask)

--- a/mahjax/red_mahjong/env.py
+++ b/mahjax/red_mahjong/env.py
@@ -1087,11 +1087,41 @@ def _make_legal_action_mask_after_discard(
     return mask
 
 
+def _discard_tile_mask_after_chi(hand_after_chi: Array, target: Array, action: Array) -> Array:
+    """
+    Tile-type discard mask after CHI with kuikae (swap-calling) prohibited.
+    - ``hand_after_chi`` is the caller's hand (with red) after the CHI meld is removed.
+    - Prohibit the swap-calling tile type (if any) and the called tile type.
+    """
+    prohibitive_tile_type = Meld.prohibitive_tile_type_after_chi(action, target)
+    tile_mask = hand_after_chi > 0
+    tile_mask = jax.lax.cond(
+        prohibitive_tile_type >= 0,
+        lambda: _set_tile_type_action(tile_mask, prohibitive_tile_type, FALSE),
+        lambda: tile_mask,
+    )
+    tile_mask = _set_tile_type_action(tile_mask, Tile.to_tile_type(target), FALSE)
+    return tile_mask
+
+
 def _mask_for_chi(hand: Array, tile: Array) -> Array:
     """
     - Check if the player can play CHI with the target tile
+    - A CHI is legal only when at least one discard remains after the kuikae
+      restrictions; otherwise it would produce an active state with an all-false
+      legal action mask (see issue #61).
     """
-    chi_results = jax.vmap(Hand.can_chi, in_axes=(None, None, 0))(hand, tile, CHI_ACTIONS)
+
+    def _can_chi_and_discard(action: Array) -> Array:
+        can_chi = Hand.can_chi(hand, tile, action)
+        has_discard = jax.lax.cond(
+            can_chi,
+            lambda: _discard_tile_mask_after_chi(Hand.chi(hand, tile, action), tile, action).any(),
+            lambda: FALSE,
+        )
+        return can_chi & has_discard
+
+    chi_results = jax.vmap(_can_chi_and_discard)(CHI_ACTIONS)
     legal_action_mask = ZERO_MASK_1D.at[CHI_ACTIONS].set(chi_results)
     return legal_action_mask
 
@@ -1579,14 +1609,7 @@ def _make_legal_action_mask_after_chi(
     - Prohibit eating changes (喰いかえ)
     - If the prohibited tile is 5, also prohibit red tiles
     """
-    prohibitive_tile_type = Meld.prohibitive_tile_type_after_chi(action, target)
-    tile_mask = hand[c_p] > 0
-    tile_mask = jax.lax.cond(
-        prohibitive_tile_type >= 0,
-        lambda: _set_tile_type_action(tile_mask, prohibitive_tile_type, FALSE),
-        lambda: tile_mask,
-    )
-    tile_mask = _set_tile_type_action(tile_mask, Tile.to_tile_type(target), FALSE)
+    tile_mask = _discard_tile_mask_after_chi(hand[c_p], target, action)
     player_mask = ZERO_MASK_1D.at[: Tile.NUM_TILE_TYPE_WITH_RED].set(tile_mask)
     # Build the legal action mask for the player
     legal_action_mask_4p = ZERO_MASK_2D.at[c_p].set(player_mask)

--- a/tests/no_red_mahjong/test_env.py
+++ b/tests/no_red_mahjong/test_env.py
@@ -30,6 +30,7 @@ from mahjax.no_red_mahjong.env import (
     _draw_after_kan,
     _pass,
     _make_legal_action_mask_after_chi,
+    _mask_for_chi,
     _abortive_draw_normal,
     _next_round,
     _kan,
@@ -59,6 +60,7 @@ jitted_open_kan = jax.jit(_open_kan)
 jitted_pon = jax.jit(_pon)
 jitted_chi = jax.jit(_chi)
 jitted_make_legal_action_mask_after_chi = jax.jit(_make_legal_action_mask_after_chi)
+jitted_mask_for_chi = jax.jit(_mask_for_chi)
 jitted_pass = jax.jit(_pass)
 jitted_riichi = jax.jit(_riichi)
 jitted_ron = jax.jit(_ron)
@@ -734,6 +736,25 @@ class TestEnv(unittest.TestCase):
         legal_action_mask = jitted_make_legal_action_mask_after_chi(self.state, hand, 0, 2, Action.CHI_R)
         expected_legal_action_mask = base_legal_action_mask.at[2].set(False) # target tile is prohibited
         self.assertEqual(jnp.all(legal_action_mask[0] == expected_legal_action_mask), True)
+
+    def test_mask_for_chi_forbids_forced_kuikae(self):
+        # Regression test for issue #61: a CHI that leaves no legal discard after
+        # kuikae (swap-calling) restrictions must not be offered as a legal action,
+        # otherwise executing it produces an active state with an all-false mask.
+        # Hand 1123444m (with two open melds held elsewhere). Calling 1m or 4m
+        # consumes 2m3m and leaves only 1m/4m, all forbidden as discards by kuikae.
+        hand = jnp.zeros(Tile.NUM_TILE_TYPE, dtype=jnp.int8)
+        hand = hand.at[0].set(2).at[1].set(1).at[2].set(1).at[3].set(3)  # 1123444m
+        # Chi 1m: only CHI_L (1m+23m) is possible; every remaining discard is kuikae.
+        mask_1m = jitted_mask_for_chi(hand, jnp.int8(0))
+        self.assertEqual(bool(jnp.any(mask_1m[Action.CHI_L : Action.CHI_R + 1])), False)
+        # Chi 4m: only CHI_R (234m) is possible; every remaining discard is kuikae.
+        mask_4m = jitted_mask_for_chi(hand, jnp.int8(3))
+        self.assertEqual(bool(jnp.any(mask_4m[Action.CHI_L : Action.CHI_R + 1])), False)
+        # Sanity: with a spare 9m in hand, chi 1m leaves a legal discard and is allowed.
+        hand_ok = hand.at[3].set(2).at[8].set(1)  # 1123449m
+        mask_ok = jitted_mask_for_chi(hand_ok, jnp.int8(0))
+        self.assertEqual(bool(mask_ok[Action.CHI_L]), True)
 
     def test_pass(self):
         # Check pass handling for queued callers, furiten-by-pass, and target clearing.

--- a/tests/red_mahjong/test_env.py
+++ b/tests/red_mahjong/test_env.py
@@ -10,6 +10,7 @@ from mahjax.red_mahjong.env import (
     _init,
     _kan,
     _make_legal_action_mask_after_draw,
+    _mask_for_chi,
     _next_meld_player,
     _next_ron_player,
     _replace_state,
@@ -56,6 +57,27 @@ def test_tsumogiri_action_history_records_actual_tile_and_flag() -> None:
     assert int(next_state.round_state.action_history[0, 0]) == int(state.current_player)
     assert int(next_state.round_state.action_history[1, 0]) == last_draw
     assert int(next_state.round_state.action_history[2, 0]) == 1
+
+
+def test_mask_for_chi_forbids_forced_kuikae() -> None:
+    # Regression test for issue #61: a CHI that leaves no legal discard after
+    # kuikae (swap-calling) restrictions must not be offered as a legal action,
+    # otherwise executing it produces an active state with an all-false mask.
+    # Hand 1123444m (with two open melds held elsewhere). Calling 1m or 4m
+    # consumes 2m3m and leaves only 1m/4m, all forbidden as discards by kuikae.
+    hand = jnp.zeros(Tile.NUM_TILE_TYPE_WITH_RED, dtype=jnp.int8)
+    hand = hand.at[0].set(2).at[1].set(1).at[2].set(1).at[3].set(3)  # 1123444m
+    chi_slice = slice(Action.CHI_L, Action.CHI_R_RED + 1)
+    # Chi 1m: only CHI_L (1m+23m) is possible; every remaining discard is kuikae.
+    mask_1m = _mask_for_chi(hand, jnp.int8(0))
+    assert not bool(jnp.any(mask_1m[chi_slice]))
+    # Chi 4m: only CHI_R (234m) is possible; every remaining discard is kuikae.
+    mask_4m = _mask_for_chi(hand, jnp.int8(3))
+    assert not bool(jnp.any(mask_4m[chi_slice]))
+    # Sanity: with a spare 9m in hand, chi 1m leaves a legal discard and is allowed.
+    hand_ok = hand.at[3].set(2).at[8].set(1)  # 1123449m
+    mask_ok = _mask_for_chi(hand_ok, jnp.int8(0))
+    assert bool(mask_ok[Action.CHI_L])
 
 
 def test_next_meld_player_prioritizes_ron_then_distance() -> None:


### PR DESCRIPTION
resolve #61 

`_mask_for_chi` only checked whether a CHI could be formed (`Hand.can_chi`), not whether any legal discard remained after the post-CHI kuikae (swap-calling) restrictions. A CHI could therefore be offered as legal even when every resulting discard is prohibited, producing an active non-terminal state with an all-false legal action mask (e.g. hand 1123444m calling 1m or 4m).

Extract the post-CHI discard mask into `_discard_tile_mask_after_chi` and reuse it in both `_make_legal_action_mask_after_chi` and `_mask_for_chi`, so the pre-action legality check and post-action mask generation share identical semantics. `_mask_for_chi` now requires `can_chi` and a non-empty post-CHI discard mask. Applies to both red_mahjong and no_red_mahjong.