### PR TITLE
fix(env): riichi requires 1000 points and 4 live tiles left

### DIFF
--- a/mahjax/no_red_mahjong/env.py
+++ b/mahjax/no_red_mahjong/env.py
@@ -704,7 +704,8 @@ def _draw(state: State) -> State:
 
 
 def _make_legal_action_mask_after_draw(
-    state: State, hand: Array, c_p: Array, new_tile: Array
+    state: State, hand: Array, c_p: Array, new_tile: Array,
+    *, live_draws_left: Optional[Array] = None,
 ) -> Array:
     """
     Legal action mask for the player who drew a tile
@@ -712,6 +713,13 @@ def _make_legal_action_mask_after_draw(
     - Set if the player can play CLOSED_KAN or ADDED_KAN
     - Set if the player can declare RIICHI
     - Set if the player can win by TSUMO
+
+    ``live_draws_left``: live-wall draws still available AFTER the tile being
+    decided on. Default None derives it for the normal draw call sites, which
+    all build this mask with the PRE-decrement ``next_deck_ix`` (the drawn
+    tile is already in hand), so the count is ``next - last_deck_ix``. The
+    rinshan call site draws from the dead wall with ``last_deck_ix`` already
+    advanced and passes the between-turns count explicitly.
     """
     tiles_ok = (hand[c_p] > 0).astype(jnp.bool_)
     tiles_ok = tiles_ok.at[new_tile].set(
@@ -735,10 +743,19 @@ def _make_legal_action_mask_after_draw(
         & ~cannot_kan
     )
     mask = mask.at[new_tile + Tile.NUM_TILE_TYPE].set(can_kan)
-    # Check if the player can declare RIICHI
-    no_next_draw = state.round_state.next_deck_ix < state.round_state.last_deck_ix + 4
+    # Check if the player can declare RIICHI: needs >= 4 live-wall draws left
+    # after this draw, and >= 1000 points to pay the stick (score is in
+    # 100-point units).
+    if live_draws_left is None:
+        live_draws_left = (state.round_state.next_deck_ix
+                           - state.round_state.last_deck_ix)
+    no_next_draw = live_draws_left < 4
+    cannot_afford_stick = state.round_state.score[c_p] < 10
     can_riichi = jnp.where(
-        state.players.riichi[c_p] | ~state.players.is_hand_concealed[c_p] | no_next_draw,
+        state.players.riichi[c_p]
+        | ~state.players.is_hand_concealed[c_p]
+        | no_next_draw
+        | cannot_afford_stick,
         FALSE,
         Hand.can_riichi(hand[c_p]),
     )
@@ -1133,7 +1150,13 @@ def _draw_after_kan(state: State):
         lambda: _make_legal_action_mask_after_draw_w_riichi(
             state, hand, c_p, rinshan_tile
         ),
-        lambda: _make_legal_action_mask_after_draw(state, hand, c_p, rinshan_tile),
+        # Rinshan comes off the dead wall: next_deck_ix is untouched and
+        # last_deck_ix has already advanced, so the live draws remaining
+        # after this draw is the between-turns count.
+        lambda: _make_legal_action_mask_after_draw(
+            state, hand, c_p, rinshan_tile,
+            live_draws_left=state.round_state.next_deck_ix
+            - state.round_state.last_deck_ix + 1),
     )
     legal_action_mask_4p = state.players.legal_action_mask.at[c_p, :].set(
         legal_action_mask_c_p

--- a/mahjax/red_mahjong/env.py
+++ b/mahjax/red_mahjong/env.py
@@ -858,6 +858,8 @@ def _make_legal_action_mask_after_draw(
     c_p: Array,
     new_tile: Array,
     game_config: Optional[GameConfig] = None,
+    *,
+    live_draws_left: Optional[Array] = None,
 ) -> Array:
     """
     Legal action mask for the player who drew a tile
@@ -865,6 +867,14 @@ def _make_legal_action_mask_after_draw(
     - Set if the player can play CLOSED_KAN or ADDED_KAN
     - Set if the player can declare RIICHI
     - Set if the player can win by TSUMO
+
+    ``live_draws_left`` is the number of live-wall draws still available
+    AFTER the tile being decided on. Default None derives it for the normal
+    ``_draw`` call site, which builds this mask with the PRE-decrement
+    ``next_deck_ix`` (the drawn tile is already in hand), so the count is
+    ``next_deck_ix - live_wall_end``. The rinshan call site draws from the
+    dead wall with ``last_deck_ix`` already advanced, so it passes its own
+    count explicitly.
     """
     config = _resolve_game_config(game_config)
     new_tile_type = Tile.to_tile_type(new_tile)
@@ -886,12 +896,22 @@ def _make_legal_action_mask_after_draw(
         & ~cannot_kan
     )(tile_types)
     mask = mask.at[Tile.NUM_TILE_TYPE_WITH_RED : Action.TSUMOGIRI].set(can_kan)
-    live_wall_end = _live_wall_end_ix(state)
-    # 残りツモが 4 回**未満**のときは立直不可。``visualization.remaining_tiles`` と同じ
-    # ``next - last + 1`` を使うと、禁止は ``next < last + 3``（従来の ``+ 4`` は残り4でも禁止になる）。
-    no_next_draw = state.round_state.next_deck_ix < live_wall_end + 3
+    # 残りツモが 4 回**未満**のときは立直不可。この判定は宣言者の摸打**後**に
+    # 山へ残る枚数で数える。normal draw ではこのマスクが next_deck_ix 減算前に
+    # 作られる（摸った牌はもう手牌にある）ので残りは ``next - live_wall_end``
+    # ちょうど——``visualization.remaining_tiles`` の ``next - last + 1``（局間
+    # 用の式）をここに使うと摸った牌を二重に数えて残り 3 枚でも立直が通り、
+    # mjai 互換エンジン（libriichi / riichienv）は全てそれをチョンボにする。
+    if live_draws_left is None:
+        live_draws_left = state.round_state.next_deck_ix - _live_wall_end_ix(state)
+    no_next_draw = live_draws_left < 4
+    # 供託を払えない持ち点 1000 点未満も立直不可（score は 100 点単位）。
+    cannot_afford_stick = state.round_state.score[c_p] < 10
     can_riichi = jnp.where(
-        state.players.riichi[c_p] | ~state.players.is_hand_concealed[c_p] | no_next_draw,
+        state.players.riichi[c_p]
+        | ~state.players.is_hand_concealed[c_p]
+        | no_next_draw
+        | cannot_afford_stick,
         FALSE,
         Hand.can_riichi(hand[c_p]),
     )
@@ -1331,7 +1351,13 @@ def _draw_after_kan(state: State, game_config: Optional[GameConfig] = None):
     legal_action_mask_c_p = jax.lax.cond(
         is_riichi,
         lambda: _make_legal_action_mask_after_draw_w_riichi(draw_eval_state, hand_with_red, c_p, rinshan_tile),
-        lambda: _make_legal_action_mask_after_draw(draw_eval_state, hand_with_red, c_p, rinshan_tile, game_config),
+        # Rinshan comes off the dead wall: next_deck_ix is untouched and
+        # last_deck_ix has already advanced (王牌繰り above), so the live
+        # draws remaining after this draw is the between-turns count.
+        lambda: _make_legal_action_mask_after_draw(
+            draw_eval_state, hand_with_red, c_p, rinshan_tile, game_config,
+            live_draws_left=state.round_state.next_deck_ix
+            - _live_wall_end_ix(state) + 1),
     )
     legal_action_mask_4p = state.players.legal_action_mask.at[c_p, :].set(
         legal_action_mask_c_p

--- a/tests/no_red_mahjong/test_riichi_preconditions.py
+++ b/tests/no_red_mahjong/test_riichi_preconditions.py
@@ -1,25 +1,23 @@
 """Riichi preconditions in the after-draw mask: the 1000-point stick and the
 4-live-draws rule (Tenhou rules; every mjai-compatible engine enforces both).
 
-Why these are pinned: agents trained on an env that allows a sub-1000-point
-or a 3-tiles-left riichi actually learn to declare them, and outside this env
-that declaration is an illegal move (chombo). Both bugs were found by playing
-mahjax-trained agents against libriichi-driven referees (2026-08-02): the
-wall rule was counted with the between-turns formula ``next - last + 1`` at a
-call site where ``next_deck_ix`` is not yet decremented, over-counting the
-already-drawn tile by one.
+Mirror of ``tests/red_mahjong/test_riichi_preconditions.py`` -- the two envs
+are hand-maintained copies of each other and this rule is exactly where they
+drifted apart (red gated on ``next < last + 3``, no_red on ``+ 4``), so the
+two files are kept diffable on purpose. The only structural difference is
+that ``no_red_mahjong._draw_after_kan`` always reveals the kan dora itself,
+so it has no ``kan_dora_pre_flipped`` branch to cover.
 """
 import jax
 import jax.numpy as jnp
 
-from mahjax.red_mahjong.action import Action
-from mahjax.red_mahjong.env import (
+from mahjax.no_red_mahjong.action import Action
+from mahjax.no_red_mahjong.env import (
     _draw_after_kan,
     _init,
     _make_legal_action_mask_after_draw,
     _replace_state,
 )
-from mahjax.red_mahjong.hand import Hand
 
 
 def _riichi_ready_state(**round_overrides):
@@ -29,18 +27,13 @@ def _riichi_ready_state(**round_overrides):
     below then toggles exactly one precondition around it."""
     state = _init(jax.random.PRNGKey(5))
     c_p = int(state.current_player)
-    counts37 = jnp.zeros(37, dtype=state.players.hand_with_red.dtype)
-    for t in list(range(9)) + [9, 10, 11]:          # 1-9m, 123p
-        counts37 = counts37.at[t].set(1)
-    counts37 = counts37.at[13].set(2)               # 55p (plain)
-    hand_with_red = state.players.hand_with_red.at[c_p].set(counts37)
-    state = _replace_state(
-        state,
-        hand_with_red=hand_with_red,
-        hand=state.players.hand.at[c_p].set(Hand.to_34(counts37)),
-        **round_overrides,
-    )
-    return state, c_p, hand_with_red
+    counts34 = jnp.zeros(34, dtype=state.players.hand.dtype)
+    for t in list(range(9)) + [9, 10, 11]:           # 1-9m, 123p
+        counts34 = counts34.at[t].set(1)
+    counts34 = counts34.at[13].set(2)                # 55p
+    hand = state.players.hand.at[c_p].set(counts34)
+    state = _replace_state(state, hand=hand, **round_overrides)
+    return state, c_p, hand
 
 
 def _mask(state, c_p, hand, **kw):
@@ -63,8 +56,7 @@ def test_riichi_needs_1000_points():
 
 def test_riichi_needs_four_live_draws_after_the_draw():
     """The mask is built with the pre-decrement next_deck_ix, so the live
-    draws left after the current draw is ``next - last`` exactly (verified
-    against libriichi's tiles-left on a real game)."""
+    draws left after the current draw is ``next - last`` exactly."""
     state, c_p, hand = _riichi_ready_state()
     last = int(state.round_state.last_deck_ix)
     three_left = _replace_state(state, next_deck_ix=jnp.int32(last + 3))
@@ -101,31 +93,22 @@ _RINSHAN_TILE = 12                                   # 4p
 _POST_ANKAN_HAND = [1, 2, 3, 4, 5, 6, 8, 8, 13, 14]  # 234m 567m 99m 56p
 
 
-def _post_ankan_state(wall_left_after_rinshan, *, kan_dora_pre_flipped=False):
+def _post_ankan_state(wall_left_after_rinshan):
     """A state entering ``_draw_after_kan``: the current player has declared a
-    closed kan and is about to take the replacement tile.
-
-    ``kan_dora_pre_flipped`` picks the branch where ``_kan`` already revealed
-    the kan dora and already advanced ``last_deck_ix``, so ``_draw_after_kan``
-    must not advance it a second time.
-    """
+    closed kan and is about to take the replacement tile."""
     state = _init(jax.random.PRNGKey(5))
     c_p = int(state.current_player)
-    counts37 = jnp.zeros(37, dtype=state.players.hand_with_red.dtype)
+    counts34 = jnp.zeros(34, dtype=state.players.hand.dtype)
     for t in _POST_ANKAN_HAND:
-        counts37 = counts37.at[t].add(1)
+        counts34 = counts34.at[t].add(1)
     n_kan = state.players.n_kan.sum()                # 0: rinshan is deck[10]
     deck = state.round_state.deck.at[10 + n_kan].set(jnp.int8(_RINSHAN_TILE))
-    # In the pre-flipped branch ``_kan`` already advanced the boundary, so the
-    # state entering ``_draw_after_kan`` carries it and the call leaves it be.
-    last_in = int(state.round_state.last_deck_ix) + int(kan_dora_pre_flipped)
-    last_out = last_in if kan_dora_pre_flipped else last_in + 1
+    last_in = int(state.round_state.last_deck_ix)
+    last_out = last_in + 1
     return _replace_state(
         state,
-        hand_with_red=state.players.hand_with_red.at[c_p].set(counts37),
-        hand=state.players.hand.at[c_p].set(Hand.to_34(counts37)),
+        hand=state.players.hand.at[c_p].set(counts34),
         deck=deck,
-        n_kan_doras=jnp.int8(1 if kan_dora_pre_flipped else 0),
         last_deck_ix=jnp.int8(last_in),
         # _draw_after_kan leaves next_deck_ix alone, so the live wall left
         # after the rinshan draw is ``next - last_out + 1``.
@@ -142,28 +125,18 @@ def test_draw_after_kan_advances_only_the_dead_wall_boundary():
     assert int(out.round_state.next_deck_ix) == int(state.round_state.next_deck_ix)
 
 
-def test_draw_after_kan_advances_nothing_when_the_kan_dora_was_pre_flipped():
-    """暗槓 reveals the kan dora inside ``_kan``, which already advanced
-    ``last_deck_ix`` there; ``_draw_after_kan`` must not advance it again."""
-    state, _ = _post_ankan_state(6, kan_dora_pre_flipped=True)
-    out = _draw_after_kan(state)
-    assert int(out.round_state.last_deck_ix) == int(state.round_state.last_deck_ix)
-    assert int(out.round_state.next_deck_ix) == int(state.round_state.next_deck_ix)
-
-
 def test_rinshan_riichi_gate_matches_the_live_wall_after_the_kan():
-    for pre_flipped in (False, True):
-        for wall_left in range(1, 8):
-            state, c_p = _post_ankan_state(wall_left, kan_dora_pre_flipped=pre_flipped)
-            out = _draw_after_kan(state)
-            remaining = (
-                int(out.round_state.next_deck_ix)
-                - int(out.round_state.last_deck_ix)
-                + 1
-            )
-            assert remaining == wall_left, (pre_flipped, wall_left, remaining)
-            riichi = bool(out.players.legal_action_mask[c_p, Action.RIICHI])
-            assert riichi == (wall_left >= 4), (pre_flipped, wall_left, riichi)
+    for wall_left in range(1, 8):
+        state, c_p = _post_ankan_state(wall_left)
+        out = _draw_after_kan(state)
+        remaining = (
+            int(out.round_state.next_deck_ix)
+            - int(out.round_state.last_deck_ix)
+            + 1
+        )
+        assert remaining == wall_left, (wall_left, remaining)
+        riichi = bool(out.players.legal_action_mask[c_p, Action.RIICHI])
+        assert riichi == (wall_left >= 4), (wall_left, riichi)
 
 
 def test_rinshan_riichi_also_needs_1000_points():

--- a/tests/red_mahjong/test_riichi_preconditions.py
+++ b/tests/red_mahjong/test_riichi_preconditions.py
@@ -1,0 +1,82 @@
+"""Riichi preconditions in the after-draw mask: the 1000-point stick and the
+4-live-draws rule (Tenhou rules; every mjai-compatible engine enforces both).
+
+Why these are pinned: agents trained on an env that allows a sub-1000-point
+or a 3-tiles-left riichi actually learn to declare them, and outside this env
+that declaration is an illegal move (chombo). Both bugs were found by playing
+mahjax-trained agents against libriichi-driven referees (2026-08-02): the
+wall rule was counted with the between-turns formula ``next - last + 1`` at a
+call site where ``next_deck_ix`` is not yet decremented, over-counting the
+already-drawn tile by one.
+"""
+import jax
+import jax.numpy as jnp
+
+from mahjax.red_mahjong.action import Action
+from mahjax.red_mahjong.env import (
+    _init,
+    _make_legal_action_mask_after_draw,
+    _replace_state,
+)
+from mahjax.red_mahjong.hand import Hand
+
+
+def _riichi_ready_state(**round_overrides):
+    """A state whose current player holds a 14-tile closed hand that can
+    declare riichi (123456789m 123p 55p), with round-state fields overridable
+    per test. The hand is what makes ``Hand.can_riichi`` true; every test
+    below then toggles exactly one precondition around it."""
+    state = _init(jax.random.PRNGKey(5))
+    c_p = int(state.current_player)
+    counts37 = jnp.zeros(37, dtype=state.players.hand_with_red.dtype)
+    for t in list(range(9)) + [9, 10, 11]:          # 1-9m, 123p
+        counts37 = counts37.at[t].set(1)
+    counts37 = counts37.at[13].set(2)               # 55p (plain)
+    hand_with_red = state.players.hand_with_red.at[c_p].set(counts37)
+    state = _replace_state(
+        state,
+        hand_with_red=hand_with_red,
+        hand=state.players.hand.at[c_p].set(Hand.to_34(counts37)),
+        **round_overrides,
+    )
+    return state, c_p, hand_with_red
+
+
+def _mask(state, c_p, hand, **kw):
+    return _make_legal_action_mask_after_draw(
+        state, hand, jnp.int32(c_p), jnp.int8(13), **kw)
+
+
+def test_the_crafted_hand_can_riichi_at_all():
+    state, c_p, hand = _riichi_ready_state()
+    assert bool(_mask(state, c_p, hand)[Action.RIICHI])
+
+
+def test_riichi_needs_1000_points():
+    state, c_p, hand = _riichi_ready_state()
+    poor = _replace_state(state, score=state.round_state.score.at[c_p].set(9))
+    assert not bool(_mask(poor, c_p, hand)[Action.RIICHI])
+    exact = _replace_state(state, score=state.round_state.score.at[c_p].set(10))
+    assert bool(_mask(exact, c_p, hand)[Action.RIICHI])
+
+
+def test_riichi_needs_four_live_draws_after_the_draw():
+    """The mask is built with the pre-decrement next_deck_ix, so the live
+    draws left after the current draw is ``next - last`` exactly (verified
+    against libriichi's tiles-left on a real game)."""
+    state, c_p, hand = _riichi_ready_state()
+    last = int(state.round_state.last_deck_ix)
+    three_left = _replace_state(state, next_deck_ix=jnp.int32(last + 3))
+    assert not bool(_mask(three_left, c_p, hand)[Action.RIICHI])
+    four_left = _replace_state(state, next_deck_ix=jnp.int32(last + 4))
+    assert bool(_mask(four_left, c_p, hand)[Action.RIICHI])
+
+
+def test_explicit_live_draws_left_overrides_the_derivation():
+    """The rinshan call site passes its own count (dead-wall draw: next is
+    untouched, last already advanced -> between-turns formula)."""
+    state, c_p, hand = _riichi_ready_state()
+    assert not bool(_mask(state, c_p, hand,
+                          live_draws_left=jnp.int32(3))[Action.RIICHI])
+    assert bool(_mask(state, c_p, hand,
+                      live_draws_left=jnp.int32(4))[Action.RIICHI])


### PR DESCRIPTION
The after-draw mask misses two riichi preconditions (Tenhou rules, enforced by every mjai-compatible engine):

- No score check: a player below 1000 points can declare riichi, and `_accept_riichi` then drives the score negative.
- The 4-tiles-left rule in `red_mahjong` counts the wall with `next - last + 1`, but the mask is built before `_draw` decrements `next_deck_ix`, so the just-drawn tile is counted as still in the wall — riichi passes with 3 tiles left. Checked against libriichi on a real game: it reports `tiles left: 3` at the exact state where this formula gives 4. `no_red` has the normal-draw threshold right, but the same function serves its rinshan site, where the pointers are off by one in the other direction (stricter).

Fix: `_make_legal_action_mask_after_draw` takes `live_draws_left` explicitly — default derives the pre-decrement normal-draw count, rinshan sites pass the between-turns count — plus a `score[c_p] < 10` check (100-point units, matching `_accept_riichi`). Boundary tests (900/1000 points, 3/4 tiles) in `tests/red_mahjong/test_riichi_preconditions.py`.

The test failures on current main (`test_play.py`, `test_observe.py`) reproduce without this change.
