### PR TITLE
fix(no_red): observation carried no round-wind signal

### DIFF
--- a/mahjax/no_red_mahjong/observation.py
+++ b/mahjax/no_red_mahjong/observation.py
@@ -73,8 +73,14 @@ def _observe_dict(state: State) -> Dict:
     _round = state.round_state.round
     honba = state.round_state.honba
     kyotaku = state.round_state.kyotaku
-    prevalent_wind = state.round_state.seat_wind[c_p]
-    seat_wind = state.round_state.init_wind[c_p]
+    # Same semantics as red_mahjong/observation.py: prevalent_wind is the round
+    # wind derived from the kyoku counter (rounds 0-3 East, 4-7 South, ...),
+    # matching what yaku scoring uses; seat_wind is the current player's seat
+    # wind, which rotates with the dealer. Previously prevalent_wind returned
+    # the seat wind and seat_wind returned the initial (chicha) wind, so the
+    # observation carried no round-wind signal at all.
+    prevalent_wind = jnp.int8(state.round_state.round // 4)
+    seat_wind = state.round_state.seat_wind[c_p]
     dora_indicators = state.round_state.dora_indicators[:5]  # (5,) Maximum 5 dora indicators
     return {
         "hand": hand_c_p_14,

--- a/tests/no_red_mahjong/test_observe.py
+++ b/tests/no_red_mahjong/test_observe.py
@@ -74,7 +74,10 @@ class TestObserveDict(TestCase):
         self.assertEqual(obs["round"].item(), 3)
         self.assertEqual(obs["honba"].item(), 2)
         self.assertEqual(obs["kyotaku"].item(), 4)
-        self.assertEqual(obs["prevalent_wind"].item(), 2)
+        # round 3 is East-4, so the round wind is still East (rounds 0-3): 0.
+        # The old expectation (2) matched the pre-fix implementation, which
+        # returned the current player's seat wind under this key.
+        self.assertEqual(obs["prevalent_wind"].item(), 0)
         self.assertEqual(obs["seat_wind"].item(), 2)
         np.testing.assert_array_equal(
             np.array(obs["dora_indicators"]),


### PR DESCRIPTION
_observe_dict returned the current player's seat wind under "prevalent_wind" and the initial (chicha) wind under "seat_wind", so no field in the observation actually encoded the round wind -- a policy could not tell an East round from a South round, and "seat_wind" stopped being true as soon as the dealership rotated.

Align with red_mahjong/observation.py, which already has the correct semantics: prevalent_wind = round // 4 (matching what yaku scoring uses), seat_wind = round_state.seat_wind[c_p].

The test expectation for prevalent_wind changes 2 -> 0 accordingly: round 3 is East-4, so the round wind is East.