### PR TITLE
fix(env): next round key from step

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -100,7 +100,6 @@ Held common across all four players.
 
 | Field | Shape | Type | Meaning |
 | :--- | :---: | :--- | :--- |
-| `rng_key` | `(2,)` | `uint32` | JAX PRNG key used to deal the current round. |
 | `action_history` | `(3, 200)` | `int8` | Per-step action history. Row 0 acting player, row 1 action payload (discarded tile for discards, raw action id otherwise), row 2 tsumogiri flag. |
 | `round` | `()` | `int8` | Round index (`0`-based). |
 | `round_limit` | `()` | `int8` | Round limit derived from `round_mode`: `4` for `east`, `8` for `half`. |

--- a/docs/visualization.md
+++ b/docs/visualization.md
@@ -59,14 +59,16 @@ import jax.numpy as jnp
 import mahjax
 
 env = mahjax.make("no_red_mahjong")
-state = env.init(jax.random.PRNGKey(0))
+rng = jax.random.PRNGKey(0)
+state = env.init(rng)
 history = [state]
 
 for _ in range(40):
     if bool(state.terminated | state.truncated):
         break
     action = jnp.argmax(state.legal_action_mask).astype(jnp.int32)
-    state = env.step(state, action)
+    rng, step_key = jax.random.split(rng)
+    state = env.step(state, action, step_key)
     history.append(state)
 
 mahjax.save_svg_animation(
@@ -84,14 +86,16 @@ import jax.numpy as jnp
 import mahjax
 
 env = mahjax.make("no_red_mahjong")
-state = env.init(jax.random.PRNGKey(0))
+rng = jax.random.PRNGKey(0)
+state = env.init(rng)
 history = [state]
 
 for _ in range(40):
     if bool(state.terminated | state.truncated):
         break
     action = jnp.argmax(state.legal_action_mask).astype(jnp.int32)
-    state = env.step(state, action)
+    rng, step_key = jax.random.split(rng)
+    state = env.step(state, action, step_key)
     history.append(state)
 
 mahjax.save_svg_animation(

--- a/examples/bc.py
+++ b/examples/bc.py
@@ -122,7 +122,7 @@ def visualize_game(cfg, train_state):
     
     step = 0
     while not state.terminated and step < cfg.viz_max_steps:
-        rng, k_act, k_rule = jax.random.split(rng, 3)
+        rng, k_act, k_rule, k_step = jax.random.split(rng, 4)
         if state.current_player == agent_seat:
             obs = env.observe(state)
             # Add batch dim
@@ -131,7 +131,7 @@ def visualize_game(cfg, train_state):
             action = policy_fn(obs_batched, mask_batched, k_act)[0]
         else:
             action = rule_based_player(state, k_rule)
-        state = jitted_step(state, action)
+        state = jitted_step(state, action, k_step)
         history.append(state)
         step += 1
             

--- a/mahjax/core.py
+++ b/mahjax/core.py
@@ -149,7 +149,7 @@ class Env(abc.ABC):
         env: Env = mahjax.make("no_red_mahjong")
         state = env.init(jax.random.PRNGKey(0))
         action = jax.random.int32(4)
-        state = env.step(state, action)
+        state = env.step(state, action, jax.random.PRNGKey(1))
         ```
 
     """
@@ -179,7 +179,9 @@ class Env(abc.ABC):
         Args:
             state: State: Current state of the game
             action: Array: Action to be performed
-            key: PRNGKey: Pseudo-random generator key in JAX
+            key: PRNGKey: Pseudo-random generator key in JAX. Required — a step
+                that ends a round deals the next wall from it, and the state
+                carries no rng of its own.
 
         Returns:
             State: State after processing the action

--- a/mahjax/no_red_mahjong/env.py
+++ b/mahjax/no_red_mahjong/env.py
@@ -61,7 +61,6 @@ _PLAYER_FIELDS = {
 }
 
 _ROUND_FIELDS = {
-    "rng_key",
     "action_history",
     "shanten_current_player",
     "round",
@@ -252,8 +251,16 @@ class NoRedMahjong(Env):
         action: Array,
         key: Optional[Array] = None,
     ) -> State:
-        del key
-        """Step function."""
+        """Step function.
+
+        ``key`` deals the wall whenever this step ends a round, so it is
+        required: the state carries no rng of its own.
+        """
+        if key is None:
+            raise ValueError(
+                "step() requires a PRNG key: a step that ends a round deals the "
+                "next wall from it, and the state carries no rng of its own."
+            )
         is_illegal = ~state.legal_action_mask[action]
         current_player = state.current_player
         state = _replace_state(state,   # type:ignore
@@ -263,7 +270,7 @@ class NoRedMahjong(Env):
         # If the state is already terminated or truncated, environment does not take usual step,
         # but return the same state with zero-rewards for all players
         step_fn = _step_auto if self.next_round_style == "auto" else _step_dummy_share
-        stepped_state = _replace_state(step_fn(state, action), step_count=state.step_count + 1)
+        stepped_state = _replace_state(step_fn(state, action, key), step_count=state.step_count + 1)
         state = jax.lax.cond(
             (state.terminated | state.truncated),
             lambda: _replace_state(state, rewards=jnp.zeros_like(state.rewards)),  # type: ignore
@@ -282,7 +289,7 @@ class NoRedMahjong(Env):
         if self.next_round_style == "auto":
             state = jax.lax.cond(
                 state.round_state.terminated_round & ~state.terminated & ~jnp.bool_(self.one_round),
-                lambda: _advance_to_next_round_auto(state),
+                lambda: _advance_to_next_round_auto(state, key),
                 lambda: state,
             )
         # Taking illegal action leads to immediate game terminal with negative reward
@@ -347,10 +354,13 @@ def _init(rng: PRNGKey) -> State:
     Initialize the state
     - Generate the initial hand
     - Set decks
-    - Set game-related variables (dealer, seat wind, last player, deck, dora indicators, ura dora indicators, hand, rng key)
+    - Set game-related variables (dealer, seat wind, last player, deck, dora indicators, ura dora indicators, hand)
     - Calculate the can_win
     - Calculate the YAKU for the initial hand
     - Generate the legal action mask
+
+    The state carries no rng: later rounds are dealt from the key passed to
+    ``step``. The split below is kept only so this deal stays bitwise the same.
 
     Args:
         rng (PRNGKey): Random number generator key
@@ -358,7 +368,7 @@ def _init(rng: PRNGKey) -> State:
     Returns:
         State: Initial state of the game
     """
-    rng, subkey = jax.random.split(rng)
+    rng, _ = jax.random.split(rng)
     current_player = jnp.int8(jax.random.randint(rng, (), 0, 4))
     last_player = jnp.int8(-1)
     deck = Tile.from_tile_id_to_tile(
@@ -431,11 +441,10 @@ def _init(rng: PRNGKey) -> State:
 def _init_for_next_round(rng: PRNGKey, state: State) -> State:
     """
     Initialize the state for the next round
-    - Generate the new deck
-    - Set game-related variables (last player, deck, dora indicators, ura dora indicators, hand, rng key)
+    - Generate the new deck from ``rng`` (the key given to ``step``)
+    - Set game-related variables (last player, deck, dora indicators, ura dora indicators, hand)
     - Succeed the process of _next_round (dealer, seat wind, round, honba, kyotaku, score, etc.)
     """
-    rng, subkey = jax.random.split(rng)
     last_player = jnp.int8(-1)
     deck = Tile.from_tile_id_to_tile(
         jax.random.permutation(rng, jnp.arange(136))
@@ -455,7 +464,6 @@ def _init_for_next_round(rng: PRNGKey, state: State) -> State:
         dora_indicators=dora_indicators,
         ura_dora_indicators=ura_dora_indicators,
         hand=init_hand,
-        rng_key=subkey,
     )
     can_ron = v_can_win(state.players.hand, TILE_RANGE)  # (4, 34)
     c_p = (
@@ -565,7 +573,7 @@ def _finalize_step_state(state: State) -> State:
     return _replace_state(state, shanten_current_player=shanten_val)  # type:ignore
 
 
-def _dispatch_action_dummy_share(state: State, action: Array) -> State:
+def _dispatch_action_dummy_share(state: State, action: Array, key: PRNGKey) -> State:
     discard_state = _discard(state, action)
     kan_state = _kan(state, action)
     riichi_state = _riichi(state)
@@ -574,7 +582,7 @@ def _dispatch_action_dummy_share(state: State, action: Array) -> State:
     pon_state = _pon(state, action)
     chi_state = _chi(state, action)
     pass_state = _pass(state)
-    next_round_state = _next_round(state)
+    next_round_state = _next_round(state, key)
     fn_idx = ACTION_FUN_MAP[action]
     return jax.lax.switch(
         fn_idx,
@@ -623,26 +631,28 @@ def _dispatch_action_auto(state: State, action: Array) -> State:
     )
 
 
-def _step_dummy_share(state: State, action: Array) -> State:
+def _step_dummy_share(state: State, action: Array, key: PRNGKey) -> State:
     """Step used by ``next_round_style='dummy_share'``.
 
     Dispatch table includes the dummy-rotation ``_next_round`` branch (selected
     when ``action == DUMMY``). Used by the UI and by tests that exercise the
-    four-DUMMY share phase.
+    four-DUMMY share phase. ``key`` deals the next round's wall.
     """
     action_history = _append_action_history(state, action)
     state = _replace_state(state, action_history=action_history)  # type:ignore
-    state = _dispatch_action_dummy_share(state, action)
+    state = _dispatch_action_dummy_share(state, action, key)
     return _finalize_step_state(state)
 
 
-def _step_auto(state: State, action: Array) -> State:
+def _step_auto(state: State, action: Array, key: PRNGKey) -> State:
     """Step used by ``next_round_style='auto'`` (RL default).
 
     Skips the dummy-rotation ``_next_round`` branch — round transitions are
     handled by the auto-advance in ``NoRedMahjong.step`` so each round ends in
-    a single env.step call.
+    a single env.step call. ``key`` is therefore consumed there, not here; it
+    is accepted so both step functions share one signature.
     """
+    del key
     action_history = _append_action_history(state, action)
     state = _replace_state(state, action_history=action_history)  # type:ignore
     state = _dispatch_action_auto(state, action)
@@ -1663,9 +1673,9 @@ def _abortive_draw_normal(state: State) -> State:
     )
 
 
-def _next_round(state: State) -> State:
+def _next_round(state: State, key: PRNGKey) -> State:
     """
-    Move to the next round
+    Move to the next round (``key`` deals the new wall)
     - Process the next round
     - Move the dealer
     - Process the round
@@ -1737,11 +1747,8 @@ def _next_round(state: State) -> State:
             will_dealer_continue, dealer, (dealer + 1) % 4
         )  # if the dealer continues, the dealer is kept, otherwise the dealer is incremented
 
-        rng, subkey = jax.random.split(s.round_state.rng_key)
-
         # ★ Initialize only at this timing
         base_next = _make_state(
-            rng_key=subkey,
             current_player=next_dealer,  # Start from the dealer
             dealer=next_dealer,
             seat_wind=_calc_wind(next_dealer),
@@ -1750,7 +1757,7 @@ def _next_round(state: State) -> State:
             kyotaku=s.round_state.kyotaku,
             score=s.round_state.score,
         )
-        next_round_state = _init_for_next_round(subkey, base_next)
+        next_round_state = _init_for_next_round(key, base_next)
 
         terminated_state = _make_state(
             score=s.round_state.score,
@@ -1797,7 +1804,7 @@ def _next_round(state: State) -> State:
     )
 
 
-def _advance_to_next_round_auto(state: State) -> State:
+def _advance_to_next_round_auto(state: State, key: PRNGKey) -> State:
     """``auto`` next_round_style: round transition without DUMMY sharing.
 
     Called when ``terminated_round`` becomes True (RON / TSUMO / 流局) and
@@ -1846,9 +1853,7 @@ def _advance_to_next_round_auto(state: State) -> State:
     )
     next_dealer = jnp.where(will_dealer_continue, dealer, (dealer + 1) % 4)
 
-    rng, subkey = jax.random.split(state.round_state.rng_key)
     base_next = _make_state(
-        rng_key=subkey,
         current_player=next_dealer,
         dealer=next_dealer,
         seat_wind=_calc_wind(next_dealer),
@@ -1859,7 +1864,7 @@ def _advance_to_next_round_auto(state: State) -> State:
         kyotaku=state.round_state.kyotaku,
         score=state.round_state.score,
     )
-    next_round_state = _init_for_next_round(subkey, base_next)
+    next_round_state = _init_for_next_round(key, base_next)
     next_round_state = _replace_state(next_round_state,
         current_player=jnp.int8(next_round_state.round_state.dealer),
         rewards=state.rewards,

--- a/mahjax/no_red_mahjong/env.py
+++ b/mahjax/no_red_mahjong/env.py
@@ -360,7 +360,8 @@ def _init(rng: PRNGKey) -> State:
     - Generate the legal action mask
 
     The state carries no rng: later rounds are dealt from the key passed to
-    ``step``. The split below is kept only so this deal stays bitwise the same.
+    ``step``. Dealer and wall draw from independent subkeys, so the dealer is
+    not a deterministic function of the wall.
 
     Args:
         rng (PRNGKey): Random number generator key
@@ -368,11 +369,11 @@ def _init(rng: PRNGKey) -> State:
     Returns:
         State: Initial state of the game
     """
-    rng, _ = jax.random.split(rng)
-    current_player = jnp.int8(jax.random.randint(rng, (), 0, 4))
+    dealer_key, wall_key = jax.random.split(rng)
+    current_player = jnp.int8(jax.random.randint(dealer_key, (), 0, 4))
     last_player = jnp.int8(-1)
     deck = Tile.from_tile_id_to_tile(
-        jax.random.permutation(rng, jnp.arange(136))
+        jax.random.permutation(wall_key, jnp.arange(136))
     ).astype(
         jnp.int8
     )  # (0-34)

--- a/mahjax/no_red_mahjong/state.py
+++ b/mahjax/no_red_mahjong/state.py
@@ -13,11 +13,10 @@
 # limitations under the License.
 
 
-import jax
 import jax.numpy as jnp
 
 from mahjax._src.struct import dataclass
-from mahjax._src.types import Array, PRNGKey
+from mahjax._src.types import Array
 from mahjax.core import EnvId
 from mahjax.no_red_mahjong.action import Action
 from mahjax.no_red_mahjong.meld import EMPTY_MELD
@@ -107,7 +106,6 @@ class PlayerStateArrays:
 
 @dataclass
 class RoundState:
-    rng_key: PRNGKey = jax.random.PRNGKey(0)
     # action history (player, action, is_tsumogiri), 70 (discard) + 70 (every pass) + 16 (four players meld 4 times) + 16 (discard for the melds) + 4 (dummy actions) + 20 (buffer)
     action_history: Array = jnp.full((3, 200), -1, dtype=jnp.int8)
     shanten_current_player: Array = jnp.int8(0)

--- a/mahjax/red_mahjong/env.py
+++ b/mahjax/red_mahjong/env.py
@@ -412,12 +412,13 @@ def _init(rng: PRNGKey, game_config: Optional[GameConfig] = None) -> State:
     Initialize the state.
 
     The state carries no rng: later rounds are dealt from the key passed to
-    ``step``. The split below is kept only so this deal stays bitwise the same.
+    ``step``. Dealer and wall draw from independent subkeys, so the dealer is
+    not a deterministic function of the wall.
     """
-    rng, _ = jax.random.split(rng)
-    current_player = jnp.int8(jax.random.randint(rng, (), 0, 4))
+    dealer_key, wall_key = jax.random.split(rng)
+    current_player = jnp.int8(jax.random.randint(dealer_key, (), 0, 4))
     last_player = jnp.int8(-1)
-    deck = Tile.from_tile_id_to_tile(jax.random.permutation(rng, jnp.arange(136))).astype(jnp.int8)
+    deck = Tile.from_tile_id_to_tile(jax.random.permutation(wall_key, jnp.arange(136))).astype(jnp.int8)
     deck = _apply_red_five_config(deck, game_config)
     init_hand_with_red = Hand.make_init_hand(deck)
     init_hand = jax.vmap(Hand.to_34)(init_hand_with_red)

--- a/mahjax/red_mahjong/env.py
+++ b/mahjax/red_mahjong/env.py
@@ -87,7 +87,6 @@ _PLAYER_FIELDS = {
 }
 
 _ROUND_FIELDS = {
-    "rng_key",
     "action_history",
     "shanten_current_player",
     "round",
@@ -306,8 +305,16 @@ class RedMahjong(Env):
         action: Array,
         key: Optional[Array] = None,
     ) -> State:
-        del key
-        """Step function."""
+        """Step function.
+
+        ``key`` deals the wall whenever this step ends a round, so it is
+        required: the state carries no rng of its own.
+        """
+        if key is None:
+            raise ValueError(
+                "step() requires a PRNG key: a step that ends a round deals the "
+                "next wall from it, and the state carries no rng of its own."
+            )
         is_illegal = ~state.legal_action_mask[action]
         current_player = state.current_player
         state = _replace_state(
@@ -317,7 +324,7 @@ class RedMahjong(Env):
 
 
         stepped_state = _replace_state(
-            self._step_fn(state, action, self.game_config),
+            self._step_fn(state, action, key, self.game_config),
             step_count=state.step_count + 1,
         )
         state = jax.lax.cond(
@@ -334,7 +341,7 @@ class RedMahjong(Env):
         if self.next_round_style == "auto":
             state = jax.lax.cond(
                 state.round_state.terminated_round & ~state.terminated & ~jnp.bool_(self.one_round),
-                lambda: _advance_to_next_round_auto(state, self.game_config),
+                lambda: _advance_to_next_round_auto(state, key, self.game_config),
                 lambda: state,
             )
         state = jax.lax.cond(
@@ -355,8 +362,9 @@ class RedMahjong(Env):
         action: Array,
         key: Optional[Array] = None,
     ) -> tuple[State, Array]:
-        del key
-        return verify_step(state, action, self.game_config)
+        if key is None:
+            raise ValueError("verify_step() requires a PRNG key; see step().")
+        return verify_step(state, action, key, self.game_config)
 
     def observe(self, state: State) -> Array:
         assert isinstance(state, State)
@@ -402,8 +410,11 @@ class RedMahjong(Env):
 def _init(rng: PRNGKey, game_config: Optional[GameConfig] = None) -> State:
     """
     Initialize the state.
+
+    The state carries no rng: later rounds are dealt from the key passed to
+    ``step``. The split below is kept only so this deal stays bitwise the same.
     """
-    rng, subkey = jax.random.split(rng)
+    rng, _ = jax.random.split(rng)
     current_player = jnp.int8(jax.random.randint(rng, (), 0, 4))
     last_player = jnp.int8(-1)
     deck = Tile.from_tile_id_to_tile(jax.random.permutation(rng, jnp.arange(136))).astype(jnp.int8)
@@ -473,8 +484,8 @@ def _init_for_next_round(
 def _prepare_next_round_assets(
     rng: PRNGKey,
     game_config: Optional[GameConfig] = None,
-) -> Tuple[PRNGKey, Array, Array, Array, Array, Array, Array]:
-    rng, subkey = jax.random.split(rng)
+) -> Tuple[Array, Array, Array, Array, Array, Array]:
+    """Deal the next round's wall from ``rng`` (the key given to ``step``)."""
     deck = Tile.from_tile_id_to_tile(jax.random.permutation(rng, jnp.arange(136))).astype(jnp.int8)
     deck = _apply_red_five_config(deck, game_config)
     init_hand_with_red = Hand.make_init_hand(deck)
@@ -482,16 +493,16 @@ def _prepare_next_round_assets(
     dora_indicators = jnp.array([deck[9], -1, -1, -1, -1], dtype=jnp.int8)
     ura_dora_indicators = jnp.array([deck[8], -1, -1, -1, -1], dtype=jnp.int8)
     can_ron = v_can_win(init_hand, TILE_RANGE)
-    return subkey, deck, dora_indicators, ura_dora_indicators, init_hand, init_hand_with_red, can_ron
+    return deck, dora_indicators, ura_dora_indicators, init_hand, init_hand_with_red, can_ron
 
 
 def _init_for_next_round_from_prepared(
     state: State,
-    prepared: Tuple[PRNGKey, Array, Array, Array, Array, Array, Array],
+    prepared: Tuple[Array, Array, Array, Array, Array, Array],
     game_config: Optional[GameConfig] = None,
 ) -> State:
     last_player = jnp.int8(-1)
-    subkey, deck, dora_indicators, ura_dora_indicators, init_hand, init_hand_with_red, can_ron = prepared
+    deck, dora_indicators, ura_dora_indicators, init_hand, init_hand_with_red, can_ron = prepared
     state = _replace_state(
         state,
         last_player=last_player,
@@ -500,7 +511,6 @@ def _init_for_next_round_from_prepared(
         ura_dora_indicators=ura_dora_indicators,
         hand=init_hand,
         hand_with_red=init_hand_with_red,
-        rng_key=subkey,
     )
     c_p = state.current_player
     new_tile = state.round_state.deck[state.round_state.next_deck_ix]
@@ -565,7 +575,7 @@ def _append_action_history(state: State, action: Array) -> Array:
 
 
 def _step_dummy_share(
-    state: State, action: Array, game_config: Optional[GameConfig] = None
+    state: State, action: Array, key: PRNGKey, game_config: Optional[GameConfig] = None
 ) -> State:
     """Step used by ``next_round_style='dummy_share'``.
 
@@ -576,12 +586,12 @@ def _step_dummy_share(
     """
     action_history = _append_action_history(state, action)
     state = _replace_state(state, action_history=action_history)  # type:ignore
-    state = _dispatch_action_dummy_share(state, action, game_config)
+    state = _dispatch_action_dummy_share(state, action, key, game_config)
     return _finalize_step_state(state, game_config, update_shanten=TRUE)
 
 
 def _step_auto(
-    state: State, action: Array, game_config: Optional[GameConfig] = None
+    state: State, action: Array, key: PRNGKey, game_config: Optional[GameConfig] = None
 ) -> State:
     """Step used by ``next_round_style='auto'`` (RL default).
 
@@ -592,7 +602,7 @@ def _step_auto(
     """
     action_history = _append_action_history(state, action)
     state = _replace_state(state, action_history=action_history)  # type:ignore
-    state = _dispatch_action_auto(state, action, game_config)
+    state = _dispatch_action_auto(state, action, key, game_config)
     return _finalize_step_state(state, game_config, update_shanten=TRUE)
 
 
@@ -602,7 +612,7 @@ _step = _step_dummy_share
 
 
 def _dispatch_action_dummy_share(
-    state: State, action: Array, game_config: Optional[GameConfig] = None
+    state: State, action: Array, key: PRNGKey, game_config: Optional[GameConfig] = None
 ) -> State:
     discard_state = _discard(state, action, game_config)
     kan_state = _kan(state, action, game_config)
@@ -612,18 +622,17 @@ def _dispatch_action_dummy_share(
     pon_state = _pon(state, action)
     chi_state = _chi(state, action)
     pass_state = _pass(state, game_config)
-    _, next_round_rng = jax.random.split(state.round_state.rng_key)
-    prepared_next_round = _prepare_next_round_assets(next_round_rng)
+    prepared_next_round = _prepare_next_round_assets(key, game_config)
     special_next_round_state = _special_next_round(
         state,
+        key,
         game_config,
-        next_round_rng=next_round_rng,
         prepared_next_round=prepared_next_round,
     )
     next_round_state = _next_round(
         state,
+        key,
         game_config,
-        next_round_rng=next_round_rng,
         prepared_next_round=prepared_next_round,
     )
     fn_idx = ACTION_FUN_MAP[action]
@@ -645,7 +654,7 @@ def _dispatch_action_dummy_share(
 
 
 def _dispatch_action_auto(
-    state: State, action: Array, game_config: Optional[GameConfig] = None
+    state: State, action: Array, key: PRNGKey, game_config: Optional[GameConfig] = None
 ) -> State:
     """Dispatch table for ``auto`` next_round_style. Drops the ``_next_round``
     (dummy rotation) computation — its slot is a no-op since ``DUMMY`` is
@@ -660,14 +669,7 @@ def _dispatch_action_auto(
     pon_state = _pon(state, action)
     chi_state = _chi(state, action)
     pass_state = _pass(state, game_config)
-    _, next_round_rng = jax.random.split(state.round_state.rng_key)
-    prepared_next_round = _prepare_next_round_assets(next_round_rng)
-    special_next_round_state = _special_next_round(
-        state,
-        game_config,
-        next_round_rng=next_round_rng,
-        prepared_next_round=prepared_next_round,
-    )
+    special_next_round_state = _special_next_round(state, key, game_config)
     fn_idx = ACTION_FUN_MAP[action]
     return jax.lax.switch(
         fn_idx,
@@ -687,7 +689,7 @@ def _dispatch_action_auto(
 
 
 def _dispatch_action_lazy(
-    state: State, action: Array, game_config: Optional[GameConfig] = None
+    state: State, action: Array, key: PRNGKey, game_config: Optional[GameConfig] = None
 ) -> State:
     """Lazy dispatcher used by :func:`verify_step` only. Avoids the eager
     pre-computation of every branch — branches are built as ``lambda s: ...``
@@ -706,25 +708,26 @@ def _dispatch_action_lazy(
             lambda s: _pon(s, action),
             lambda s: _chi(s, action),
             lambda s: _pass(s, game_config),
-            lambda s: _special_next_round(s, game_config),
-            lambda s: _next_round(s, game_config),
+            lambda s: _special_next_round(s, key, game_config),
+            lambda s: _next_round(s, key, game_config),
         ],
         state,
     )
 
 
 def _step_verify_lazy(
-    state: State, action: Array, game_config: Optional[GameConfig] = None
+    state: State, action: Array, key: PRNGKey, game_config: Optional[GameConfig] = None
 ) -> State:
     action_history = _append_action_history(state, action)
     state = _replace_state(state, action_history=action_history)
-    state = _dispatch_action_lazy(state, action, game_config)
+    state = _dispatch_action_lazy(state, action, key, game_config)
     return _finalize_step_state(state, game_config, update_shanten=FALSE)
 
 
 def verify_step(
     state: State,
     action: Array,
+    key: PRNGKey,
     game_config: Optional[GameConfig] = None,
 ) -> tuple[State, Array]:
     """Step variant for replay verification.
@@ -734,10 +737,14 @@ def verify_step(
     is illegal, the input state is returned unchanged together with
     ``is_illegal=True``. Used by ``mahjax_tenhou_test`` to compare env behavior
     against tenhou mjlogs without triggering the env's penalty path.
+
+    ``key`` deals the next round's wall on a round-ending action; replays
+    overwrite it with the logged wall, but it is still required so this shares
+    ``step``'s contract.
     """
     is_illegal = ~state.legal_action_mask[action]
     stepped_state = _replace_state(
-        _step_verify_lazy(state, action, game_config),
+        _step_verify_lazy(state, action, key, game_config),
         step_count=state.step_count + 1,
     )
     state = jax.lax.cond(
@@ -1990,18 +1997,15 @@ def _abortive_draw_normal(state: State) -> State:
 
 def _special_next_round(
     state: State,
+    key: PRNGKey,
     game_config: Optional[GameConfig] = None,
     *,
-    next_round_rng: Optional[PRNGKey] = None,
-    prepared_next_round: Optional[Tuple[PRNGKey, Array, Array, Array, Array, Array, Array]] = None,
+    prepared_next_round: Optional[Tuple[Array, Array, Array, Array, Array, Array]] = None,
 ) -> State:
-    if next_round_rng is None:
-        _, next_round_rng = jax.random.split(state.round_state.rng_key)
     if prepared_next_round is None:
-        prepared_next_round = _prepare_next_round_assets(next_round_rng)
+        prepared_next_round = _prepare_next_round_assets(key, game_config)
     dealer = state.round_state.dealer
     base_next = _make_state(
-        rng_key=next_round_rng,
         current_player=dealer,
         dealer=dealer,
         init_wind=state.round_state.init_wind,
@@ -2060,13 +2064,13 @@ def _mangan_tsumo(winner: Array, dealer: Array, honba: Array) -> Array:
 
 def _next_round(
     state: State,
+    key: PRNGKey,
     game_config: Optional[GameConfig] = None,
     *,
-    next_round_rng: Optional[PRNGKey] = None,
-    prepared_next_round: Optional[Tuple[PRNGKey, Array, Array, Array, Array, Array, Array]] = None,
+    prepared_next_round: Optional[Tuple[Array, Array, Array, Array, Array, Array]] = None,
 ) -> State:
     """
-    Move to the next round
+    Move to the next round (``key`` deals the new wall)
     - Process the next round
     - Move the dealer
     - Process the round
@@ -2074,10 +2078,8 @@ def _next_round(
     - DUMMY sharing: 3 times of rotation (cp to +1 mod 4) after the 4th time, the result is determined
     """
     dc = state.round_state.dummy_count  # int8
-    if next_round_rng is None:
-        _, next_round_rng = jax.random.split(state.round_state.rng_key)
     if prepared_next_round is None:
-        prepared_next_round = _prepare_next_round_assets(next_round_rng)
+        prepared_next_round = _prepare_next_round_assets(key, game_config)
 
     # ---- During the DUMMY sharing phase, only rotate ----
     def _rotate_once(s: State):
@@ -2144,7 +2146,6 @@ def _next_round(
 
         # ★ Initialize only at this timing
         base_next = _make_state(  # type: ignore
-            rng_key=next_round_rng,
             current_player=next_dealer,  # Start from the dealer
             dealer=next_dealer,
             seat_wind=_calc_wind(next_dealer),
@@ -2207,6 +2208,7 @@ def _next_round(
 
 def _advance_to_next_round_auto(
     state: State,
+    key: PRNGKey,
     game_config: Optional[GameConfig] = None,
 ) -> State:
     """``auto`` next_round_style round transition (no DUMMY sharing) for red_mahjong.
@@ -2252,10 +2254,8 @@ def _advance_to_next_round_auto(
     )
     next_dealer = jnp.where(will_dealer_continue, dealer, (dealer + 1) % 4)
 
-    _, next_round_rng = jax.random.split(state.round_state.rng_key)
-    prepared = _prepare_next_round_assets(next_round_rng, game_config)
+    prepared = _prepare_next_round_assets(key, game_config)
     base_next = _make_state(
-        rng_key=next_round_rng,
         current_player=next_dealer,
         dealer=next_dealer,
         seat_wind=_calc_wind(next_dealer),

--- a/mahjax/red_mahjong/state.py
+++ b/mahjax/red_mahjong/state.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import jax
 import jax.numpy as jnp
 
 from .constants import (
@@ -25,7 +24,6 @@ from .constants import (
 from .meld import EMPTY_MELD
 from .struct import dataclass
 from .tile import EMPTY_RIVER
-from .types import PRNGKey
 
 
 FALSE = jnp.bool_(False)
@@ -87,7 +85,6 @@ class PlayerStateArrays:
 
 @dataclass
 class RoundState:
-    rng_key: PRNGKey = jax.random.PRNGKey(0)
     action_history: jnp.ndarray = jnp.full((3, 200), -1, dtype=jnp.int8)
     shanten_current_player: jnp.int8 = jnp.int8(0)
     round: jnp.int8 = jnp.int8(0)

--- a/mahjax/red_mahjong/visualization.py
+++ b/mahjax/red_mahjong/visualization.py
@@ -607,7 +607,8 @@ def generate_play_history_states(
             if int(jnp.sum(state.legal_action_mask)) == 0:
                 break
             action = jnp.argmax(state.legal_action_mask).astype(jnp.int32)
-        state = env.step(state, action)
+        rng, step_key = jax.random.split(rng)
+        state = env.step(state, action, step_key)
         history.append(state)
         if bool(state.terminated | state.truncated):
             break

--- a/mahjax/ui/game_manager.py
+++ b/mahjax/ui/game_manager.py
@@ -479,7 +479,8 @@ class GameSession:
         mask = self.state.legal_action_mask
         ensure_valid_action(action, mask)
         prev_state = self.state
-        next_state = self._step_fn(prev_state, jnp.int32(action))
+        self.rng, step_key = jax.random.split(self.rng)
+        next_state = self._step_fn(prev_state, jnp.int32(action), step_key)
         next_state = jax.device_get(next_state)
         self.state = next_state
         self.step_counter += 1

--- a/tests/no_red_mahjong/test_env.py
+++ b/tests/no_red_mahjong/test_env.py
@@ -37,6 +37,8 @@ from mahjax.no_red_mahjong.env import (
     NoRedMahjong,
     _replace_state,
 )
+
+STEP_KEY = jax.random.PRNGKey(0)  # wall key for round transitions
 env = NoRedMahjong(round_mode="single")
 
 jitted_init = jax.jit(_init)
@@ -78,7 +80,7 @@ def _advance_after_dummy(state, steps: int = 4):
     """Advance the state after the dummy sharing is complete."""
     # If the dummy count is 0, the dummy sharing is complete, so the next round is called.
     for _ in range(steps):
-        state = jitted_next_round(state)
+        state = jitted_next_round(state, STEP_KEY)
         if int(state.round_state.dummy_count) == 0:
             # The dummy sharing is complete, so the next round is called.
             break
@@ -648,7 +650,7 @@ class TestEnv(unittest.TestCase):
 
         env_share = NoRedMahjong(round_mode="half", next_round_style="dummy_share")
         kan_state = jitted_kan(state, action)
-        ron_state = env_share.step(kan_state, jnp.int32(Action.RON))
+        ron_state = env_share.step(kan_state, jnp.int32(Action.RON), STEP_KEY)
 
         expected = jnp.zeros((Action.NUM_ACTION,), dtype=jnp.bool_).at[Action.DUMMY].set(True)
         self.assertTrue(bool(ron_state.round_state.terminated_round))
@@ -1173,7 +1175,7 @@ class TestEnv(unittest.TestCase):
 
         cps = [2]
         for _ in range(3):
-            state = jitted_next_round(state)
+            state = jitted_next_round(state, STEP_KEY)
             cps.append(int(state.current_player))
 
         # 2 -> 3 -> 0 -> 1 rotation
@@ -1218,7 +1220,7 @@ class TestEnv(unittest.TestCase):
             action_history.append(recorded_action)
             tsumogiri_history.append(1 if is_tsumogiri else (0 if is_discard else -1))
             current_player_history.append(int(state.current_player))
-            state = jitted_env_step(state, action)
+            state = jitted_env_step(state, action, STEP_KEY)
             rng, rng_sub = jax.random.split(rng)
 
         final_step_count = state.step_count
@@ -1268,7 +1270,7 @@ class TestNextRoundStyle(unittest.TestCase):
             legal_action_mask=self._ron_legal_mask(0),
             current_player=jnp.int8(0),
         )
-        next_state = env_auto.step(state, jnp.int32(Action.RON))
+        next_state = env_auto.step(state, jnp.int32(Action.RON), STEP_KEY)
         self.assertFalse(bool(next_state.terminated))
         self.assertFalse(bool(next_state.round_state.terminated_round))
         self.assertEqual(int(next_state.round_state.dummy_count), 0)
@@ -1293,7 +1295,7 @@ class TestNextRoundStyle(unittest.TestCase):
             legal_action_mask=self._ron_legal_mask(0),
             current_player=jnp.int8(0),
         )
-        next_state = env_share.step(state, jnp.int32(Action.RON))
+        next_state = env_share.step(state, jnp.int32(Action.RON), STEP_KEY)
         self.assertFalse(bool(next_state.terminated))
         self.assertTrue(bool(next_state.round_state.terminated_round))
         self.assertEqual(int(next_state.round_state.dummy_count), 0)
@@ -1309,7 +1311,7 @@ class TestNextRoundStyle(unittest.TestCase):
             legal_action_mask=self._ron_legal_mask(0),
             current_player=jnp.int8(0),
         )
-        next_state = env_auto.step(state, jnp.int32(Action.RON))
+        next_state = env_auto.step(state, jnp.int32(Action.RON), STEP_KEY)
         self.assertTrue(bool(next_state.terminated))
 
     def test_auto_game_end_sets_terminated_with_final_score(self):
@@ -1333,7 +1335,7 @@ class TestNextRoundStyle(unittest.TestCase):
             kyotaku=jnp.int8(3),
             has_won=jnp.array([False, False, False, False], dtype=jnp.bool_),
         )
-        next_state = env_auto.step(state, jnp.int32(Action.RON))
+        next_state = env_auto.step(state, jnp.int32(Action.RON), STEP_KEY)
         self.assertTrue(bool(next_state.terminated))
         # Score reflects rank_points + kyotaku on top, matching the legacy
         # round_end_share final-score computation.
@@ -1358,7 +1360,7 @@ class TestNextRoundStyle(unittest.TestCase):
             current_player=jnp.int8(0),
             last_player=jnp.int8(2),
         )
-        next_state = env_auto.step(state, jnp.int32(Action.RON))
+        next_state = env_auto.step(state, jnp.int32(Action.RON), STEP_KEY)
         # Reward shape preserved
         self.assertEqual(next_state.rewards.shape, (4,))
         # Game continues (not the final round)
@@ -1397,13 +1399,13 @@ class TestAutoDummyShareParity(unittest.TestCase):
 
         state_auto = env_auto.step(
             self._force_ron_state(env_auto, key), jnp.int32(Action.RON)
-        )
+        , STEP_KEY)
         state_share = env_share.step(
             self._force_ron_state(env_share, key), jnp.int32(Action.RON)
-        )
+        , STEP_KEY)
         rewards_at_ron = state_share.rewards  # delivered at RON step in dummy_share
         for _ in range(4):
-            state_share = env_share.step(state_share, jnp.int32(Action.DUMMY))
+            state_share = env_share.step(state_share, jnp.int32(Action.DUMMY), STEP_KEY)
 
         # Mid-game: both at next-round init.
         self.assertFalse(bool(state_auto.terminated))
@@ -1458,9 +1460,9 @@ class TestAutoDummyShareParity(unittest.TestCase):
         state_auto = _replace_state(self._force_ron_state(env_auto, key), **forced)
         state_share = _replace_state(self._force_ron_state(env_share, key), **forced)
 
-        state_auto = env_auto.step(state_auto, jnp.int32(Action.RON))
-        state_share = env_share.step(state_share, jnp.int32(Action.RON))
-        state_share = env_share.step(state_share, jnp.int32(Action.DUMMY))
+        state_auto = env_auto.step(state_auto, jnp.int32(Action.RON), STEP_KEY)
+        state_share = env_share.step(state_share, jnp.int32(Action.RON), STEP_KEY)
+        state_share = env_share.step(state_share, jnp.int32(Action.DUMMY), STEP_KEY)
 
         self.assertTrue(bool(state_auto.terminated))
         self.assertTrue(bool(state_share.terminated))

--- a/tests/no_red_mahjong/test_play.py
+++ b/tests/no_red_mahjong/test_play.py
@@ -14,6 +14,8 @@ from mahjax.no_red_mahjong.shanten import Shanten
 from mahjax.no_red_mahjong.yaku import Yaku
 from mahjax.no_red_mahjong.players import rule_based_player
 
+STEP_KEY = jax.random.PRNGKey(0)  # wall key for round transitions
+
 jitted_init = jax.jit(_init)
 jitted_step = jax.jit(_step)
 jitted_shanten_discard = jax.jit(Shanten.discard)
@@ -822,7 +824,7 @@ class TestPlay(unittest.TestCase):
                 ls = state
                 action = act_randomly(rng, state.legal_action_mask)
                 rng, rng_sub = jax.random.split(rng)
-                state_next = jitted_step(state, action)
+                state_next = jitted_step(state, action, STEP_KEY)
                 assert state_next.step_count <= len(state_next.round_state.action_history[0]), "step_count should be less than the length of action_history"
                 print("seed", i, "step", steps, "current_player", int(ls.current_player), "action", action, "next_deck_ix", int(ls.round_state.next_deck_ix), "remaining_deck_ix", int(ls.round_state.next_deck_ix - ls.round_state.last_deck_ix + 1))
                 try:
@@ -858,7 +860,7 @@ class TestPlay(unittest.TestCase):
                     state.legal_action_mask
                 )
                 rng, rng_sub = jax.random.split(rng)
-                state_next = jitted_step(state, action)
+                state_next = jitted_step(state, action, STEP_KEY)
                 assert state_next.step_count <= len(state_next.round_state.action_history[0]), "step_count should be less than the length of action_history"
                 print("seed", i, "step", steps, "current_player", int(ls.current_player), "action", action)
                 try:
@@ -888,7 +890,7 @@ class TestPlay(unittest.TestCase):
                 ls = state
                 action = play_kan_orientedly(rng, ls.players.hand[ls.current_player], state.legal_action_mask)
                 rng, rng_sub = jax.random.split(rng, 2)
-                state_next = jitted_step(state, action)
+                state_next = jitted_step(state, action, STEP_KEY)
                 assert state_next.step_count <= len(state_next.round_state.action_history[0]), "step_count should be less than the length of action_history"
                 print(
                     "seed", i,
@@ -925,7 +927,7 @@ class TestPlay(unittest.TestCase):
                 ls = state
                 action = jitted_rule_based_player(state, rng)
                 rng, rng_sub = jax.random.split(rng, 2)
-                state_next = jitted_step(state, action)
+                state_next = jitted_step(state, action, STEP_KEY)
                 assert state_next.step_count <= len(state_next.round_state.action_history[0]), "step_count should be less than the length of action_history"
                 print(
                     "seed", i,

--- a/tests/no_red_mahjong/test_special_case.py
+++ b/tests/no_red_mahjong/test_special_case.py
@@ -5,6 +5,8 @@ from mahjax.no_red_mahjong.action import Action
 from mahjax.no_red_mahjong.state import FIRST_DRAW_IDX
 from mahjax.no_red_mahjong.env import _init, _step, _make_legal_action_mask_after_draw, _make_legal_action_mask_after_draw_w_riichi, _discard, _next_meld_player, _tsumo, _next_round, _replace_state
 
+STEP_KEY = jax.random.PRNGKey(0)  # wall key for round transitions
+
 jitted_init = jax.jit(_init)
 jitted_step = jax.jit(_step)
 jitted_make_legal_action_mask_after_draw = jax.jit(_make_legal_action_mask_after_draw)
@@ -21,7 +23,7 @@ def _advance_after_dummy(state, steps: int = 4):
     # If the dummy count is 0, the dummy sharing is complete, so the next round is called.
     # If the dummy count is not 0, the dummy sharing is not complete, so the next round is called.
     for _ in range(steps):
-        state = jitted_next_round(state)
+        state = jitted_next_round(state, STEP_KEY)
         if int(state.round_state.dummy_count) == 0:
             # The dummy sharing is complete, so the next round is called.
             break

--- a/tests/no_red_mahjong/test_visualize.py
+++ b/tests/no_red_mahjong/test_visualize.py
@@ -11,6 +11,8 @@ from mahjax.no_red_mahjong.players import rule_based_player
 from mahjax.no_red_mahjong.yaku import Yaku
 from mahjax.no_red_mahjong.env import _dora_array
 
+STEP_KEY = jax.random.PRNGKey(0)  # wall key for round transitions
+
 
 IDX_AFTER_FIRST_DRAW = FIRST_DRAW_IDX - 1
 
@@ -47,7 +49,7 @@ class TestVisualize(unittest.TestCase):
         while not state.terminated and i <= 100:
             a = act_randomly(rng, state.legal_action_mask)
             print('step', i, 'current_player', state.current_player, 'action', a)
-            state = jitted_step(state, a)
+            state = jitted_step(state, a, STEP_KEY)
             i += 1
             #print("target", state.round_state.target, "action", a, "current_player", state.current_player, "melds", state.players.melds)
             #save_svg(state, f"fig/test_animation_{i}.svg")
@@ -63,7 +65,7 @@ class TestVisualize(unittest.TestCase):
         while not state.round_state.terminated_round and i <= 100:
             a = jnp.where(state.legal_action_mask[Action.DUMMY], Action.DUMMY, Action.TSUMOGIRI)
             print('step', i, 'current_player', state.current_player, 'action', a)
-            state = jitted_step(state, a)
+            state = jitted_step(state, a, STEP_KEY)
             i += 1
             #print("target", state.round_state.target, "action", a, "current_player", state.current_player, "melds", state.players.melds)
             #save_svg(state, f"fig/test_animation_{i}.svg")
@@ -117,7 +119,7 @@ class TestVisualize(unittest.TestCase):
                 print(yaku, fan, fu)
 
             print('step', i, 'current_player', state.current_player, 'action', a)
-            state = jitted_step(state, a)
+            state = jitted_step(state, a, STEP_KEY)
             i += 1
             states.append(state)
         print(state.round_state.score)

--- a/tests/red_mahjong/test_env.py
+++ b/tests/red_mahjong/test_env.py
@@ -21,6 +21,8 @@ from mahjax.red_mahjong.meld import Meld
 from mahjax.red_mahjong.state import default_state
 from mahjax.red_mahjong.tile import Tile
 
+STEP_KEY = jax.random.PRNGKey(0)  # wall key for round transitions
+
 
 def test_init_shape_and_first_draw_position() -> None:
     state = _init(jax.random.PRNGKey(1))
@@ -52,7 +54,7 @@ def test_mask_after_draw_has_discard_or_tsumogiri() -> None:
 def test_tsumogiri_action_history_records_actual_tile_and_flag() -> None:
     state = _init(jax.random.PRNGKey(4))
     last_draw = int(state.round_state.last_draw)
-    next_state = _step(state, jnp.int8(Action.TSUMOGIRI))
+    next_state = _step(state, jnp.int8(Action.TSUMOGIRI), STEP_KEY)
 
     assert int(next_state.round_state.action_history[0, 0]) == int(state.current_player)
     assert int(next_state.round_state.action_history[1, 0]) == last_draw
@@ -222,7 +224,7 @@ def test_robbing_kan_ron_finalizes_to_dummy_share_mask() -> None:
 
     env = RedMahjong(round_mode="half", next_round_style="dummy_share")
     kan_state = _kan(state, jnp.int32(action))
-    ron_state = env.step(kan_state, jnp.int32(Action.RON))
+    ron_state = env.step(kan_state, jnp.int32(Action.RON), STEP_KEY)
 
     expected = jnp.zeros((Action.NUM_ACTION,), dtype=jnp.bool_).at[Action.DUMMY].set(True)
     assert bool(ron_state.round_state.terminated_round)
@@ -276,8 +278,8 @@ def test_robbing_kan_second_candidate_pass_after_ron_does_not_draw_after_kan() -
 
     env = RedMahjong(round_mode="half", next_round_style="dummy_share")
     kan_state = _kan(state, jnp.int32(action))
-    first_ron_state = env.step(kan_state, jnp.int32(Action.RON))
-    pass_state = env.step(first_ron_state, jnp.int32(Action.PASS))
+    first_ron_state = env.step(kan_state, jnp.int32(Action.RON), STEP_KEY)
+    pass_state = env.step(first_ron_state, jnp.int32(Action.PASS), STEP_KEY)
 
     expected = jnp.zeros((Action.NUM_ACTION,), dtype=jnp.bool_).at[Action.DUMMY].set(True)
     assert bool(pass_state.round_state.terminated_round)
@@ -318,7 +320,7 @@ def test_red_auto_ron_advances_to_next_round_in_one_step() -> None:
         legal_action_mask=_ron_legal_mask(0),
         current_player=jnp.int8(0),
     )
-    next_state = env_auto.step(state, jnp.int32(Action.RON))
+    next_state = env_auto.step(state, jnp.int32(Action.RON), STEP_KEY)
     assert not bool(next_state.terminated)
     assert not bool(next_state.round_state.terminated_round)
     assert int(next_state.round_state.dummy_count) == 0
@@ -339,7 +341,7 @@ def test_red_dummy_share_ron_keeps_dummy_phase() -> None:
         legal_action_mask=_ron_legal_mask(0),
         current_player=jnp.int8(0),
     )
-    next_state = env_share.step(state, jnp.int32(Action.RON))
+    next_state = env_share.step(state, jnp.int32(Action.RON), STEP_KEY)
     assert not bool(next_state.terminated)
     assert bool(next_state.round_state.terminated_round)
     assert int(next_state.round_state.dummy_count) == 0
@@ -355,7 +357,7 @@ def test_red_auto_single_mode_terminates_like_legacy() -> None:
         legal_action_mask=_ron_legal_mask(0),
         current_player=jnp.int8(0),
     )
-    next_state = env_auto.step(state, jnp.int32(Action.RON))
+    next_state = env_auto.step(state, jnp.int32(Action.RON), STEP_KEY)
     assert bool(next_state.terminated)
 
 
@@ -374,7 +376,7 @@ def test_red_auto_game_end_sets_terminated_with_final_score() -> None:
         kyotaku=jnp.int8(3),
         has_won=jnp.array([False, False, False, False], dtype=jnp.bool_),
     )
-    next_state = env_auto.step(state, jnp.int32(Action.RON))
+    next_state = env_auto.step(state, jnp.int32(Action.RON), STEP_KEY)
     assert bool(next_state.terminated)
     expected = jnp.array([370, 320, 180, 160], dtype=jnp.int32)
     assert bool(jnp.all(next_state.round_state.score == expected)), (
@@ -410,11 +412,11 @@ def test_red_auto_matches_dummy_share_at_mid_game_round_transition() -> None:
     env_share = RedMahjong(round_mode="half", next_round_style="dummy_share")
     key = jax.random.PRNGKey(2026)
 
-    state_auto = env_auto.step(_force_ron_state(env_auto, key), jnp.int32(Action.RON))
-    state_share = env_share.step(_force_ron_state(env_share, key), jnp.int32(Action.RON))
+    state_auto = env_auto.step(_force_ron_state(env_auto, key), jnp.int32(Action.RON), STEP_KEY)
+    state_share = env_share.step(_force_ron_state(env_share, key), jnp.int32(Action.RON), STEP_KEY)
     rewards_at_ron = state_share.rewards  # round-end reward delivered at RON step in dummy_share
     for _ in range(4):
-        state_share = env_share.step(state_share, jnp.int32(Action.DUMMY))
+        state_share = env_share.step(state_share, jnp.int32(Action.DUMMY), STEP_KEY)
 
     # Both must land in the next-round init: mid-game ⇒ not terminated, not terminated_round.
     assert not bool(state_auto.terminated)
@@ -469,9 +471,9 @@ def test_red_auto_matches_dummy_share_at_game_end() -> None:
     state_auto = _replace_state(_force_ron_state(env_auto, key), **forced)
     state_share = _replace_state(_force_ron_state(env_share, key), **forced)
 
-    state_auto = env_auto.step(state_auto, jnp.int32(Action.RON))
-    state_share = env_share.step(state_share, jnp.int32(Action.RON))
-    state_share = env_share.step(state_share, jnp.int32(Action.DUMMY))
+    state_auto = env_auto.step(state_auto, jnp.int32(Action.RON), STEP_KEY)
+    state_share = env_share.step(state_share, jnp.int32(Action.RON), STEP_KEY)
+    state_share = env_share.step(state_share, jnp.int32(Action.DUMMY), STEP_KEY)
 
     assert bool(state_auto.terminated)
     assert bool(state_share.terminated)

--- a/tests/red_mahjong/test_parity.py
+++ b/tests/red_mahjong/test_parity.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import jax
 import jax.numpy as jnp
 
 from mahjax.red_mahjong.action import Action
@@ -257,7 +258,7 @@ def test_special_next_round_keeps_dealer_and_increments_honba() -> None:
         ),
     )
 
-    next_state = _special_next_round(state)
+    next_state = _special_next_round(state, jax.random.PRNGKey(0))
 
     assert int(next_state.current_player) == 2
     assert int(next_state.round_state.dealer) == 2

--- a/tests/test_wall_rng.py
+++ b/tests/test_wall_rng.py
@@ -1,0 +1,87 @@
+"""The wall for every round after the first comes from the key given to ``step``.
+
+The state carries no rng of its own. Before this was wired up, ``RoundState``
+held an ``rng_key`` that ``_init`` never seeded and ``step`` never consumed, so
+every wall after the first was one global sequence shared by all seeds, envs
+and runs -- the second hand's deck, deals and dora were constants of the
+library (#71).
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import mahjax
+
+ENV_NAMES = ["red_mahjong", "no_red_mahjong"]
+STYLES = ["auto", "dummy_share"]
+
+
+def _make(env_name, style):
+    return mahjax.make(env_name, round_mode="half", next_round_style=style)
+
+
+def _walls(env, init_seed, step_seed, n_walls=3, max_steps=4000):
+    """Play random legal actions and collect each distinct wall.
+
+    A round transition is exactly when the deck array changes, which works
+    under both ``next_round_style`` values (``auto`` completes the transition
+    inside one step, so ``terminated_round`` is never observable between steps).
+    """
+    state = env.init(jax.random.PRNGKey(init_seed))
+    step = jax.jit(env.step)
+    walls = [np.asarray(state.round_state.deck).copy()]
+    rng = jax.random.PRNGKey(step_seed)
+    for _ in range(max_steps):
+        if len(walls) >= n_walls or bool(state.terminated | state.truncated):
+            break
+        rng, k_act, k_step = jax.random.split(rng, 3)
+        logits = jnp.where(state.legal_action_mask, 0.0, -jnp.inf)
+        action = jax.random.categorical(k_act, logits).astype(jnp.int32)
+        state = step(state, action, k_step)
+        deck = np.asarray(state.round_state.deck)
+        if not np.array_equal(deck, walls[-1]):
+            walls.append(deck.copy())
+    return walls
+
+
+@pytest.mark.parametrize("env_name", ENV_NAMES)
+def test_state_carries_no_rng(env_name):
+    state = _make(env_name, "auto").init(jax.random.PRNGKey(0))
+    assert not hasattr(state.round_state, "rng_key")
+
+
+@pytest.mark.parametrize("env_name", ENV_NAMES)
+def test_step_without_a_key_is_rejected(env_name):
+    env = _make(env_name, "auto")
+    state = env.init(jax.random.PRNGKey(0))
+    action = int(jnp.argmax(state.legal_action_mask))
+    with pytest.raises(ValueError, match="requires a PRNG key"):
+        env.step(state, jnp.int32(action))
+
+
+@pytest.mark.parametrize("style", STYLES)
+@pytest.mark.parametrize("env_name", ENV_NAMES)
+def test_later_walls_follow_the_step_keys(env_name, style):
+    """Same init key, different step keys -> the first wall is shared (it is
+    dealt by ``init``) and every later wall differs. This is the bug: it used
+    to be the other way round, with later walls identical across everything."""
+    env = _make(env_name, style)
+    a = _walls(env, init_seed=0, step_seed=1)
+    b = _walls(env, init_seed=0, step_seed=2)
+    assert len(a) >= 3 and len(b) >= 3, "no round transition within the step budget"
+    np.testing.assert_array_equal(a[0], b[0])
+    for i in range(1, 3):
+        assert not np.array_equal(a[i], b[i]), f"wall {i} does not follow the step key"
+
+
+@pytest.mark.parametrize("style", STYLES)
+@pytest.mark.parametrize("env_name", ENV_NAMES)
+def test_walls_are_reproducible_from_the_same_keys(env_name, style):
+    env = _make(env_name, style)
+    a = _walls(env, init_seed=0, step_seed=1)
+    b = _walls(env, init_seed=0, step_seed=1)
+    assert len(a) == len(b)
+    for x, y in zip(a, b):
+        np.testing.assert_array_equal(x, y)


### PR DESCRIPTION
resolve #71 

Closes #71. Supersedes #72, which fixed the symptom by seeding the stored key; this removes the stored key instead.

### The problem

`RoundState.rng_key` existed, `_init` never seeded it, and `step` threw its `key` away (`del key`). Every reshuffle derived from that unseeded field, so every wall after the first was one global sequence shared across seeds, envs, and runs — the second hand's deck, all four deals, and the dora indicator were constants of the library. Reproduced on `main`: walls 2 and 3 are bitwise identical across seeds 0 and 424242, in both envs and under both `next_round_style` values.

For RL this is an implicit full-information oracle. From hand 2 on the whole wall is identifiable from public state, so self-play policies can memorize it — inflating in-simulator strength and collapsing the wall diversity of any multi-env rollout.

### The change

Randomness now enters through `step`, pgx style, and the state carries none of its own.

- Deleted `rng_key` from `RoundState` in both envs (and from `_ROUND_FIELDS` and `docs/api.md`).
- Threaded `step`'s `key` down to the round transition: `step` → `_step_auto` / `_step_dummy_share` → dispatch → `_next_round` / `_special_next_round` / `_advance_to_next_round_auto` / `_init_for_next_round*`.
- `key=None` now raises. Every round transition is stochastic, so any default would silently reintroduce the constant-wall bug.
- `_init` also draws the dealer and the wall from independent subkeys; they previously shared one, making the dealer a deterministic function of the wall.

Call sites updated: `core.py` docstrings, `red_mahjong/visualization.py`, `ui/game_manager.py`, `examples/bc.py`, `docs/visualization.md`. The batched examples in `README.md` and `docs/api.md` already passed `rngs` — those keys were simply being ignored until now.

### Breaking changes

- **`State.rng_key` is gone.** It was public and documented.
- **`step(state, action)` now raises**; pass a key.
- **Reproducibility is now "same key sequence", not "same init key".** That is the pgx contract and makes the randomness visible at the call site, but it changes replay for anyone driving from an init seed alone.
- **First-hand deals changed**, as a consequence of the dealer/wall split.

### Tests

New `tests/test_wall_rng.py` (12 tests, both envs × both `next_round_style`): the state exposes no `rng_key`; a keyless `step` is rejected; with a fixed init key and different step keys the first wall is shared and every later wall differs; the same key sequence reproduces the same walls. Round transitions are detected by the deck array changing, which works under `auto` too (there the transition completes inside one step, so `terminated_round` is never observable between steps).

Existing tests thread a single `STEP_KEY`; the auto-vs-`dummy_share` parity tests compare one `auto` step against `RON + 4 × DUMMY`, so both paths must deal from the same key.

Full CI-equivalent suite: 169 passed, 120 subtests. `test_play.py`'s 3 failures / 11 errors are unchanged from `main` (pre-existing).