### PR TITLE
Fix(red): illegal kyuushu / riichi ankan moves, and triple-ron payment rollback

### DIFF
--- a/mahjax/red_mahjong/env.py
+++ b/mahjax/red_mahjong/env.py
@@ -960,7 +960,7 @@ def _make_legal_action_mask_after_draw(
     can_kyuushu = (
         config.enable_special_abortive_draw
         & Hand.can_kyuushu(hand[c_p])
-        & _is_first_turn(state.round_state.next_deck_ix)
+        & _is_first_turn(state.round_state.next_deck_ix - 1)
         & (state.players.meld_counts.sum() == 0)
     )
     mask = mask.at[Action.KYUUSHU].set(can_kyuushu)
@@ -977,14 +977,11 @@ def _make_legal_action_mask_after_draw_w_riichi(
     """
     new_tile_type = Tile.to_tile_type(new_tile)
     mask = ZERO_MASK_1D.at[Action.TSUMOGIRI].set(TRUE)
-    tile_types = jnp.arange(Tile.NUM_TILE_TYPE, dtype=jnp.int32)
-    can_closed_kan = jax.vmap(
-        lambda tile_type: (
-            Hand.can_closed_kan_after_riichi(hand[c_p], tile_type, state.players.can_win[c_p])
-            & ~state.round_state.is_haitei
-        )
-    )(tile_types)
-    mask = mask.at[Tile.NUM_TILE_TYPE_WITH_RED : Action.TSUMOGIRI].set(can_closed_kan)
+    can_closed_kan = (
+        Hand.can_closed_kan_after_riichi(hand[c_p], new_tile_type, state.players.can_win[c_p])
+        & ~state.round_state.is_haitei
+    )
+    mask = mask.at[Tile.NUM_TILE_TYPE_WITH_RED + new_tile_type].set(can_closed_kan)
     mask = mask.at[Action.TSUMO].set(state.players.can_win[c_p, new_tile_type])
     return mask
 
@@ -1717,6 +1714,8 @@ def _pass(state: State, game_config: Optional[GameConfig] = None):
             furiten_by_pass=state.players.furiten_by_pass.at[c_p].set(
                 is_ron_player & ~can_robbing_kan
             ),
+            score=jnp.int32(state.round_state.score + state.rewards),
+            kyotaku=jnp.int8(0),
             legal_action_mask=ZERO_MASK_2D.at[:, Action.DUMMY].set(TRUE),
             terminated_round=TRUE,
             kan_declared=FALSE,
@@ -1811,8 +1810,9 @@ def _ron(state: State, game_config: Optional[GameConfig] = None) -> State:
     score = jnp.where(state.round_state.dealer == c_p, basic_score * 6, basic_score * 4)
     # Round up the score to the nearest multiple of 100
     score = jnp.ceil(score / 100)
-    # In double-ron, honba is paid only once on the first ron.
-    honba = jnp.where(state.players.has_won.any(), 0, state.round_state.honba * 3)
+    # In double-ron, honba and kyotaku are paid only once on the first ron.
+    is_first_ron = ~state.players.has_won.any()
+    honba = jnp.where(is_first_ron, state.round_state.honba * 3, 0)
     # Build reward array more efficiently
     normal_reward = jnp.zeros(4, dtype=jnp.float32)
     normal_reward = normal_reward.at[c_p].set(score + honba)
@@ -1824,9 +1824,10 @@ def _ron(state: State, game_config: Optional[GameConfig] = None) -> State:
     pao_reward = pao_reward.at[state.round_state.last_player].add(-score / 2 - honba)
     reward = jnp.where(config.enable_pao & is_pao, pao_reward, normal_reward)
     # The Kyotaku is already paid when the RIICHI is declared, so we only need to add the Kyotaku to the winner
-    kyotaku_bonus = 10 * (state.round_state.kyotaku)
+    kyotaku_bonus = 10 * state.round_state.kyotaku * is_first_ron
     reward = reward.at[c_p].add(kyotaku_bonus)
-    score = state.round_state.score + jnp.float32(reward)
+    pending = jnp.where(is_first_ron, jnp.zeros_like(state.rewards), state.rewards) + reward
+    score = state.round_state.score + pending
     remaining_ron_mask = ZERO_MASK_2D.at[:, Action.RON].set(
         state.players.legal_action_mask[:, Action.RON]
     )
@@ -1834,17 +1835,19 @@ def _ron(state: State, game_config: Optional[GameConfig] = None) -> State:
     next_ron_player, can_any_ron = _next_ron_player(
         remaining_ron_mask, state.round_state.last_player
     )
-    # 三家和: this is the 3rd RON declared on the same discard. Trigger
-    # ``_trigger_special_abortive_draw`` instead of applying this RON's
-    # score / has_won — abortive draw means no one wins.
-    # (The prior two RONs' scores and has_won bits have already been written
-    # to ``state`` by previous ``_ron`` calls; we leave those as-is, a known
-    # small inaccuracy vs tenhou's "no payment, no winners" rule.)
+    # 三家和: this is the 3rd RON declared on the same discard. Nobody wins, so
+    # the pending payments and has_won bits of the prior two RONs are dropped.
     is_triple_ron = (
         config.enable_special_abortive_draw
         & ((state.players.has_won.sum() + 1) >= 3)
     )
-    triple_ron_state = _trigger_special_abortive_draw(state)
+    triple_ron_state = _trigger_special_abortive_draw(
+        _replace_state(
+            state,
+            rewards=jnp.zeros_like(state.rewards),
+            has_won=jnp.zeros_like(state.players.has_won),
+        )
+    )
     # ``continue_ron`` covers both 2nd-RON (double) and 3rd-RON (triple) cases:
     # we hand the turn to the next eligible RON candidate so they can choose
     # RON / PASS. ``allow_double_ron`` config flag gates the whole multi-RON
@@ -1853,9 +1856,7 @@ def _ron(state: State, game_config: Optional[GameConfig] = None) -> State:
     continue_state = _replace_state(
         state,
         current_player=jnp.int8(next_ron_player),
-        score=jnp.int32(score),
-        rewards=jnp.float32(reward),
-        kyotaku=jnp.int8(0),
+        rewards=jnp.float32(pending),
         has_won=state.players.has_won.at[c_p].set(TRUE),
         legal_action_mask=remaining_ron_mask.at[next_ron_player, Action.PASS].set(TRUE),
         draw_next=FALSE,

--- a/tests/red_mahjong/test_parity.py
+++ b/tests/red_mahjong/test_parity.py
@@ -9,6 +9,7 @@ from mahjax.red_mahjong.env import (
     _abortive_draw_normal,
     _draw,
     _make_legal_action_mask_after_draw,
+    _make_legal_action_mask_after_draw_w_riichi,
     _mangan_tsumo,
     _pao,
     _pass,
@@ -206,6 +207,23 @@ def test_kyuushu_action_is_enabled_on_first_turn() -> None:
     assert bool(mask[Action.KYUUSHU])
 
 
+def test_kyuushu_action_is_disabled_after_the_first_turn() -> None:
+    state = default_state()
+    hand_with_red = state.players.hand_with_red.at[0].set(
+        jnp.zeros((37,), dtype=jnp.int8)
+        .at[jnp.array([0, 8, 9, 17, 18, 26, 27, 28, 29, 30, 31, 32, 33, 0])]
+        .add(1)
+    )
+    state = state.replace(
+        players=state.players.replace(hand_with_red=hand_with_red),
+        round_state=state.round_state.replace(next_deck_ix=jnp.int32(FIRST_DRAW_IDX - 4)),
+    )
+
+    mask = _make_legal_action_mask_after_draw(state, hand_with_red, jnp.int8(0), jnp.int8(0))
+
+    assert not bool(mask[Action.KYUUSHU])
+
+
 def test_kyuushu_action_is_disabled_by_game_config() -> None:
     state = default_state()
     hand_with_red = state.players.hand_with_red.at[0].set(
@@ -225,6 +243,48 @@ def test_kyuushu_action_is_disabled_by_game_config() -> None:
     )
 
     assert not bool(mask[Action.KYUUSHU])
+
+
+def _riichi_draw_state(concealed: list[int], drawn: int):
+    hand_with_red = jnp.zeros((37,), dtype=jnp.int8)
+    for tile in concealed:
+        hand_with_red = hand_with_red.at[tile].add(1)
+    can_win = jax.vmap(Hand.can_ron, in_axes=(None, 0))(
+        Hand.to_34(hand_with_red), jnp.arange(34)
+    )
+    hand_with_red = hand_with_red.at[drawn].add(1)
+    state = default_state()
+    state = state.replace(
+        current_player=jnp.int8(0),
+        players=state.players.replace(
+            hand_with_red=state.players.hand_with_red.at[0].set(hand_with_red),
+            hand=state.players.hand.at[0].set(Hand.to_34(hand_with_red)),
+            riichi=state.players.riichi.at[0].set(True),
+            can_win=state.players.can_win.at[0].set(can_win),
+        ),
+    )
+    return state, state.players.hand_with_red
+
+
+def test_riichi_closed_kan_is_offered_only_for_the_drawn_tile() -> None:
+    # 1111m 23m 456p 789p 9s waiting on 9s, then draws 4m: the 1m quad was
+    # already complete at the riichi declaration, so it cannot be kanned.
+    state, hand = _riichi_draw_state([0, 0, 0, 0, 1, 2, 12, 13, 14, 15, 16, 17, 26], 3)
+
+    mask = _make_legal_action_mask_after_draw_w_riichi(state, hand, jnp.int8(0), jnp.int8(3))
+
+    assert not bool(mask[Tile.NUM_TILE_TYPE_WITH_RED : Action.TSUMOGIRI].any())
+
+
+def test_riichi_closed_kan_is_offered_for_the_drawn_tile() -> None:
+    # 111m 234m 456p 789p 9s waiting on 9s, then draws the 4th 1m.
+    state, hand = _riichi_draw_state([0, 0, 0, 1, 2, 3, 12, 13, 14, 15, 16, 17, 26], 0)
+
+    mask = _make_legal_action_mask_after_draw_w_riichi(state, hand, jnp.int8(0), jnp.int8(0))
+
+    kan_mask = mask[Tile.NUM_TILE_TYPE_WITH_RED : Action.TSUMOGIRI]
+    assert bool(kan_mask[0])
+    assert int(kan_mask.sum()) == 1
 
 
 def test_four_winds_abortive_draw_sets_kyuushu_mask() -> None:
@@ -347,12 +407,53 @@ def test_double_ron_config_chains_ron_and_pass_resolution() -> None:
     assert int(after_first_ron.current_player) == 1
     assert bool(after_first_ron.players.legal_action_mask[1, Action.RON])
     assert bool(after_first_ron.players.legal_action_mask[1, Action.PASS])
-    assert int(after_first_ron.round_state.kyotaku) == 0
+    assert int(after_first_ron.round_state.kyotaku) == 2
 
     after_pass = _pass(after_first_ron, config)
 
     assert bool(after_pass.round_state.terminated_round)
     assert bool(after_pass.players.legal_action_mask[:, Action.DUMMY].all())
+    assert int(after_pass.round_state.kyotaku) == 0
+    assert jnp.array_equal(
+        after_pass.round_state.score,
+        jnp.int32(ron_state.round_state.score + after_first_ron.rewards),
+    )
+
+
+def test_triple_ron_drops_the_pending_payments_of_the_first_two_rons() -> None:
+    base = default_state()
+    legal_action_mask = base.players.legal_action_mask
+    for player in range(3):
+        legal_action_mask = legal_action_mask.at[player, Action.RON].set(True)
+    ron_state = base.replace(
+        current_player=jnp.int8(0),
+        legal_action_mask=legal_action_mask[0],
+        players=base.players.replace(
+            legal_action_mask=legal_action_mask,
+            fan=base.players.fan.at[:, 0].set(jnp.int32(5)),
+            fu=base.players.fu.at[:, 0].set(jnp.int32(30)),
+        ),
+        round_state=base.round_state.replace(
+            dealer=jnp.int8(3),
+            last_player=jnp.int8(3),
+            honba=jnp.int8(1),
+            kyotaku=jnp.int8(2),
+            score=jnp.array([250, 250, 250, 250], dtype=jnp.int32),
+        ),
+    )
+    config = GameConfig(allow_double_ron=jnp.bool_(True))
+
+    after_first_ron = _ron(ron_state, config)
+    after_second_ron = _ron(after_first_ron.replace(current_player=jnp.int8(1)), config)
+    after_third_ron = _ron(after_second_ron.replace(current_player=jnp.int8(2)), config)
+
+    assert jnp.array_equal(after_first_ron.round_state.score, ron_state.round_state.score)
+    assert jnp.array_equal(after_second_ron.round_state.score, ron_state.round_state.score)
+    assert jnp.array_equal(after_third_ron.round_state.score, ron_state.round_state.score)
+    assert int(after_third_ron.round_state.kyotaku) == 2
+    assert not bool(after_third_ron.players.has_won.any())
+    assert not bool(after_third_ron.rewards.any())
+    assert bool(after_third_ron.players.legal_action_mask[:, Action.KYUUSHU].all())
 
 
 def test_single_ron_when_double_ron_is_disabled() -> None:


### PR DESCRIPTION

**1. Nine terminals (九種九牌) stayed legal one draw too long.** `can_kyuushu` passed `_is_first_turn` the wall pointer from before `_draw` decrements it, so wall index 79, the dealer's *second* draw, still qualified. Over 400 seeded rounds: 7 offers before, 2 of them illegal; 5 after.

**2. Closed kan after riichi was offered for tiles other than the drawn one.** The mask evaluated all 34 tile types and ignored `new_tile`, so a quad already held at declaration could be kanned on any later turn. That flips an extra dora indicator plus ura, shifts the haitei position, and counts toward the four-kan abortive draw, so it moves both scores and round length. Now only the drawn tile type is evaluated, as `no_red_mahjong` already did.

**3. Triple ron (三家和) kept the first two rons' payments.** `_ron` settled each ron immediately, so the abortive draw left two payments, two `has_won` bits and the collected riichi sticks applied. Payments are now held in `rewards` as `pending` and committed only when the chain resolves; the triple-ron branch drops them.

Two parts of this are easy to miss:

- `_pass` has to settle too. The ordinary "one player rons, the rest pass" round ends there, not in `_ron`. Without it nobody gets paid and the riichi sticks leak into the next round.
- `pending` must be seeded to zero on the first ron. `state.rewards` carries the previous transition's value, so accumulating unconditionally charges the discarder their own riichi stick twice.

`kyotaku_bonus` is now explicitly gated on `is_first_ron`, preserving behaviour that had relied on `continue_state` zeroing `kyotaku`.

On the scenario from the notes (dealer discards into three players, two sticks on the table):

| | score | kyotaku | has_won |
| --- | --- | --- | --- |
| before | `[-6, 283, 263, 250]` | 0 | `[F, T, T, F]` |
| after | `[20, 250, 250, 250]` | 2 | `[F, F, F, F]` |

**Behaviour change worth knowing.** Mid-chain, later ron candidates now observe pre-payment `scores` and the uncollected `kyotaku`, matching how a multi-ron is actually settled once at round end. On a second ron with a third candidate still live, `rewards` reports the cumulative pending vector rather than that ron's delta; plain double ron is bit-identical to before. This only affects a loop summing `rewards` every step, already unsound because `rewards` is never cleared between steps (item 16).

**Not in this PR.** `_special_next_round` still performs no game-end judgement (item 21). The abortive-draw reason is still not recorded (item 4).

**Tests.** `tests/red_mahjong`: 116 passed, 1 skipped, up from 112. Four new tests plus one updated assertion; three of the new tests and the updated assertion fail on `main`, the fourth pins the legal riichi kan. `tests/no_red_mahjong/test_play.py` fails identically on `main` and is excluded from CI. Random rollouts over 6 seeds in both round styles terminate with the table still summing to 100000 points.
