### PR TITLE
Fix(env): wrong uma, one kyoku too many, and a lost final score

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ env = mahjax.make(
     "red_mahjong",
     round_mode="single", # "single", "east" (tonpuusen), or "half" (hanchan)
     observe_type="dict", # "dict" for Transformer, "2D" for CNN
-    order_points=[30, 10, -10, -30], # Final score bonuses (uma)
+    order_points=[300, 100, -100, -300], # Final score bonuses (uma), in hundreds of points
 )
 
 init_fn = jax.jit(jax.vmap(env.init))
@@ -155,14 +155,14 @@ You can configure the environment with:
 - `id`: the rule set, such as `red_mahjong` or `no_red_mahjong`
 - `round_mode`: `single` for a single round, `east` for tonpuusen (East-only), or `half` for hanchan (East-South)
 - `observe_type`: `dict` for transformer-style inputs or `2D` for CNN-style inputs
-- `order_points`: final placement bonuses (uma) in units of 1000 points, for example `[30, 10, -10, -30]`
+- `order_points`: final placement bonuses (uma), in hundreds of points like `score`, for example `[300, 100, -100, -300]` for 10-30 uma
 
 ```python
 env = mahjax.make(
     "red_mahjong",
     round_mode="single",
     observe_type="dict",
-    order_points=[30, 10, -10, -30],
+    order_points=[300, 100, -100, -300],
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ You can configure the environment with:
 - `id`: the rule set, such as `red_mahjong` or `no_red_mahjong`
 - `round_mode`: `single` for a single round, `east` for tonpuusen (East-only), or `half` for hanchan (East-South)
 - `observe_type`: `dict` for transformer-style inputs or `2D` for CNN-style inputs
-- `order_points`: final placement bonuses (uma), for example `[30, 10, -10, -30]`
+- `order_points`: final placement bonuses (uma) in units of 1000 points, for example `[30, 10, -10, -30]`
 
 ```python
 env = mahjax.make(

--- a/docs/api.md
+++ b/docs/api.md
@@ -24,7 +24,7 @@ env = mahjax.make(
     "red_mahjong",
     round_mode="single",   # "single", "east" (tonpuusen), or "half" (hanchan)
     next_round_style="auto",  # "auto" (default, RL) or "dummy_share" (interactive / mjai)
-    order_points=[30, 10, -10, -30],
+    order_points=[300, 100, -100, -300],
 )
 step_fn = jax.jit(jax.vmap(env.step))
 obs_fn = jax.jit(jax.vmap(env.observe))
@@ -111,7 +111,7 @@ Held common across all four players.
 | `init_wind` | `(4,)` | `int8` | Initial seat winds at the start of the game. |
 | `seat_wind` | `(4,)` | `int8` | Current seat wind per player. |
 | `dealer` | `()` | `int8` | Current dealer. |
-| `order_points` | `(4,)` | `int32` | Placement bonus / uma, in units of 1000 points. |
+| `order_points` | `(4,)` | `int32` | Placement bonus / uma, in hundreds of points like `score`. |
 | `score` | `(4,)` | `int32` | Per-player score, in hundreds of points. |
 | `deck` | `(136,)` | `int8` | Current round's shuffled wall (tile types). |
 | `next_deck_ix` | `()` | `int32` | Next index to draw from in `deck`. |

--- a/docs/api.md
+++ b/docs/api.md
@@ -104,14 +104,14 @@ Held common across all four players.
 | `round_step` | `()` | `int32` | Write cursor into `action_history`, reset to 0 each round. Do **not** index the history with `state.step_count`: that counter is hanchan-global, so it walks past the end of this per-round buffer and JAX drops the out-of-bounds scatter silently. |
 | `history_overflow` | `()` | `bool` | `True` once a round produced more actions than `action_history` can hold; the newest action then overwrites the last slot. Makes truncation observable instead of silent. |
 | `round` | `()` | `int8` | Round index (`0`-based). |
-| `round_limit` | `()` | `int8` | Round limit derived from `round_mode`: `4` for `east`, `8` for `half`. |
+| `round_limit` | `()` | `int8` | Index of the last regular kyoku, derived from `round_mode`: `3` for `east`, `7` for `half`. Play continues past it while nobody has 30000 points. |
 | `terminated_round` | `()` | `bool` | `True` on the step that ends the round (RON / TSUMO / 流局). See the round-transition section for how `auto` vs `dummy_share` expose this. |
 | `honba` | `()` | `int8` | Honba count (renchan counter). |
 | `kyotaku` | `()` | `int8` | Number of unclaimed riichi sticks on the table. |
 | `init_wind` | `(4,)` | `int8` | Initial seat winds at the start of the game. |
 | `seat_wind` | `(4,)` | `int8` | Current seat wind per player. |
 | `dealer` | `()` | `int8` | Current dealer. |
-| `order_points` | `(4,)` | `int32` | Placement bonus / uma. |
+| `order_points` | `(4,)` | `int32` | Placement bonus / uma, in units of 1000 points. |
 | `score` | `(4,)` | `int32` | Per-player score, in hundreds of points. |
 | `deck` | `(136,)` | `int8` | Current round's shuffled wall (tile types). |
 | `next_deck_ix` | `()` | `int32` | Next index to draw from in `deck`. |
@@ -162,11 +162,11 @@ the right / across / left.
 | `riichi` | `(4,)` | `bool` | Seat-rotated. Public for every seat. |
 | `is_hand_concealed` | `(4,)` | `bool` | Seat-rotated. Gates riichi legality and menzen tsumo. Deriving it from `melds` means reimplementing the rule that a closed kan keeps the hand concealed. |
 | `wall_remaining` | `()` | `int32` | Tiles still drawable from the live wall, `[0, 70]`. Drives haitei, the exhaustive draw and the riichi precondition. |
-| `round` | `()` | `int8` | Kyoku counter in `[0, round_limit]`. |
-| `round_limit` | `()` | `int8` | Last kyoku index: 4 for `east`, 8 for `single`/`half`. With `round`, how much game is left. |
+| `round` | `()` | `int8` | Kyoku counter. Exceeds `round_limit` during sudden death, up to `round_limit + 4`. |
+| `round_limit` | `()` | `int8` | Index of the last regular kyoku: 3 for `east`, 7 for `single`/`half`. With `round`, how much game is left. |
 | `honba` | `()` | `int8` | Honba count. |
 | `kyotaku` | `()` | `int8` | Riichi sticks on the table. |
-| `prevalent_wind` | `()` | `int8` | Round wind, `round // 4`. Reaches 2 (West) on the last kyoku of a `half` game. |
+| `prevalent_wind` | `()` | `int8` | Round wind, `round // 4`. Reaches 2 (West) during the sudden-death kyoku of a `half` game. |
 | `seat_wind` | `()` | `int8` | Observer's seat wind `[0-3]`; 0 is the dealer. |
 | `dora_indicators` | `(5,)` | `int8` | Indicators `[0-36]`, `-1` for unrevealed slots. |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,7 @@ env = mahjax.make(
     "red_mahjong",
     round_mode="single", # "single", "east" (tonpuusen), or "half" (hanchan)
     observe_type="dict", # "dict" for Transformer, "2D" for CNN
-    order_points=[30, 10, -10, -30], # Final score bonuses (uma)
+    order_points=[300, 100, -100, -300], # Final score bonuses (uma), in hundreds of points
 )
 
 init_fn = jax.jit(jax.vmap(env.init))
@@ -144,14 +144,14 @@ You can configure the environment with:
 - `id`: the rule set, such as `red_mahjong` or `no_red_mahjong`
 - `round_mode`: `single` for a single round, `east` for tonpuusen (East-only), or `half` for hanchan (East-South)
 - `observe_type`: `dict` for transformer-style inputs or `2D` for CNN-style inputs
-- `order_points`: final placement bonuses (uma), for example `[30, 10, -10, -30]`
+- `order_points`: final placement bonuses (uma), in hundreds of points like `score`, for example `[300, 100, -100, -300]` for 10-30 uma
 
 ```python
 env = mahjax.make(
     "red_mahjong",
     round_mode="single",
     observe_type="dict",
-    order_points=[30, 10, -10, -30],
+    order_points=[300, 100, -100, -300],
 )
 ```
 

--- a/docs/no_red_mahjong.md
+++ b/docs/no_red_mahjong.md
@@ -123,8 +123,10 @@ For how to consume these rewards in turn-based MARL training (per-player reward 
 ## Termination
 
 - `round_mode="single"` terminates after the first round ends.
-- `round_mode="east"` runs East-only progression with `round_limit=4`.
-- `round_mode="half"` runs East-South progression with `round_limit=8`.
+- `round_mode="east"` runs East-only progression with `round_limit=3` (East-1 to East-4).
+- `round_mode="half"` runs East-South progression with `round_limit=7` (East-1 to South-4).
+- If nobody holds 30000 points or more when the last kyoku ends, the deal runs on into the
+  extra rounds (西入り) and stops as soon as somebody does, or after four extra kyoku.
 
 In multi-round modes, the next-round transition behavior is controlled by `next_round_style` (see [API](api.md#round-transition-style-next_round_style)).
 

--- a/docs/no_red_mahjong.md
+++ b/docs/no_red_mahjong.md
@@ -126,7 +126,7 @@ For how to consume these rewards in turn-based MARL training (per-player reward 
 - `round_mode="east"` runs East-only progression with `round_limit=3` (East-1 to East-4).
 - `round_mode="half"` runs East-South progression with `round_limit=7` (East-1 to South-4).
 - If nobody holds 30000 points or more when the last kyoku ends, the deal runs on into the
-  extra rounds (西入り) and stops as soon as somebody does, or after four extra kyoku.
+  extra rounds (西入) and stops as soon as somebody does, or after four extra kyoku.
 
 In multi-round modes, the next-round transition behavior is controlled by `next_round_style` (see [API](api.md#round-transition-style-next_round_style)).
 

--- a/docs/red_mahjong.md
+++ b/docs/red_mahjong.md
@@ -53,8 +53,8 @@ The rule behavior is controlled through `GameConfig`. Advanced users can change 
 | `allow_open_tanyao` | `True` | Allow tanyao with open melds (`喰いタン`). |
 | `allow_kuikae` | `False` | Allow swap-calling (`喰い替え`). |
 | `seed_wall_from_key` | `True` | Use the env's PRNG key to shuffle the wall. |
-| `starting_points` | `250` | Starting score (hundreds of points). |
-| `target_points` | `300` | Target score for ending sudden death overtime. |
+| `starting_points` | `25000` | Starting score, in points. |
+| `target_points` | `30000` | Target score for ending sudden death overtime, in points. |
 | `honba_bonus` | `300` | Honba bonus payment. |
 | `riichi_bet` | `1000` | Riichi stick value. |
 
@@ -171,8 +171,10 @@ For how to consume these rewards in turn-based MARL training (per-player reward 
 ## Termination
 
 - `round_mode="single"` terminates after the first round ends.
-- `round_mode="east"` runs East-only progression with `round_limit=4`.
-- `round_mode="half"` runs East-South progression with `round_limit=8`.
+- `round_mode="east"` runs East-only progression with `round_limit=3` (East-1 to East-4).
+- `round_mode="half"` runs East-South progression with `round_limit=7` (East-1 to South-4).
+- If nobody holds 30000 points or more when the last kyoku ends, the deal runs on into the
+  extra rounds (西入り) and stops as soon as somebody does, or after four extra kyoku.
 
 In multi-round modes, the next-round transition behavior is controlled by `next_round_style` (see [API](api.md#round-transition-style-next_round_style)).
 

--- a/docs/red_mahjong.md
+++ b/docs/red_mahjong.md
@@ -174,7 +174,7 @@ For how to consume these rewards in turn-based MARL training (per-player reward 
 - `round_mode="east"` runs East-only progression with `round_limit=3` (East-1 to East-4).
 - `round_mode="half"` runs East-South progression with `round_limit=7` (East-1 to South-4).
 - If nobody holds 30000 points or more when the last kyoku ends, the deal runs on into the
-  extra rounds (西入り) and stops as soon as somebody does, or after four extra kyoku.
+  extra rounds (西入) and stops as soon as somebody does, or after four extra kyoku.
 
 In multi-round modes, the next-round transition behavior is controlled by `next_round_style` (see [API](api.md#round-transition-style-next_round_style)).
 

--- a/mahjax/core.py
+++ b/mahjax/core.py
@@ -264,7 +264,7 @@ def make(env_id: EnvId, **kwargs):  # noqa: C901
             "no_red_mahjong",
             round_mode="single",  # "single", "east" (tonpuusen), or "half" (hanchan)
             observe_type="dict", # "dict" for Transformer, "2D" for CNN
-            order_points=[30, 10, -10, -30],  # Final score bonuses (uma)
+            order_points=[300, 100, -100, -300],  # Final score bonuses (uma), in hundreds of points
         )
         ```
     """

--- a/mahjax/no_red_mahjong/env.py
+++ b/mahjax/no_red_mahjong/env.py
@@ -36,6 +36,11 @@ from mahjax.no_red_mahjong.observation import (
 FALSE = jnp.bool_(False)
 TRUE = jnp.bool_(True)
 
+# Score is in units of 100 points: the game only ends at the last kyoku once
+# someone has reached 30000, otherwise it runs on into the extra rounds.
+TARGET_SCORE = 300
+SUDDEN_DEATH_ROUNDS = 4
+
 TILE_RANGE = jnp.arange(Tile.NUM_TILE_TYPE)
 ZERO_MASK_1D = jnp.zeros(Action.NUM_ACTION, dtype=jnp.bool_)
 ZERO_MASK_2D = jnp.zeros((4, Action.NUM_ACTION), dtype=jnp.bool_)
@@ -226,7 +231,7 @@ class NoRedMahjong(Env):
             )
         self.round_mode = round_mode
         self.one_round = round_mode == "single"
-        self.round_limit = jnp.int8(4 if round_mode == "east" else 8)
+        self.round_limit = jnp.int8(3 if round_mode == "east" else 7)
         self.observe_func = _observe_dict if observe_type == "dict" else _observe_2D
         self.observe_privileged_func = _observe_privileged_dict if observe_type == "dict" else _observe_privileged_2D
         self.order_points = order_points
@@ -1742,6 +1747,39 @@ def _abortive_draw_normal(state: State) -> State:
     )
 
 
+def _final_score(round_state) -> Array:
+    """Score at game end: raw score plus uma, with the riichi sticks to the top.
+
+    ``order_points`` is expressed in units of 1000 points and ``score`` in units
+    of 100, hence the factor of 10.
+    """
+    order = jnp.argsort(-round_state.score)
+    rank_points = jnp.zeros_like(round_state.score).at[order].set(round_state.order_points * 10)
+    score = round_state.score + rank_points
+    return score.at[jnp.argmax(score)].add(10 * round_state.kyotaku)
+
+
+def _is_game_end(round_state, will_dealer_continue: Array) -> Array:
+    """Whether the hanchan/tonpuusen is over now that a kyoku has ended.
+
+    ``round`` is 0-based and ``round_limit`` is the index of the last regular
+    kyoku, so a half game ends after South-4 (``round_limit == 7``). If nobody
+    has reached ``TARGET_SCORE`` there, the deal runs on into the extra rounds
+    (西入り) and ends as soon as someone does, or unconditionally once the last
+    extra round has been played.
+    """
+    score = round_state.score
+    is_final_round = round_state.round >= round_state.round_limit
+    is_last_extra_round = round_state.round >= round_state.round_limit + SUDDEN_DEATH_ROUNDS
+    # The deal leaves the current dealer, or it stays but they are top and stop.
+    deal_passes = ~will_dealer_continue | (jnp.argmax(score) == round_state.dealer)
+    return (
+        (score < 0).any()
+        | is_last_extra_round
+        | (is_final_round & deal_passes & (score.max() >= TARGET_SCORE))
+    )
+
+
 def _next_round(state: State, key: PRNGKey) -> State:
     """
     Move to the next round (``key`` deals the new wall)
@@ -1758,39 +1796,21 @@ def _next_round(state: State, key: PRNGKey) -> State:
         is_tempai = s.players.can_win.any(axis=-1)  # (4,)
         dealer = s.round_state.dealer
         hora = s.players.has_won  # (4,)
+        has_other_than_dealer_won = hora.any() & ~hora[dealer]
         will_dealer_continue = jnp.logical_or(
-            is_tempai[dealer], hora[dealer]
-        )  # Check if the dealer continues (win or temporary win)
-        order = jnp.argsort(
-            -s.round_state.score
-        )  # Example: score=[10,20,30,40] -> order=[3,2,1,0]
-        rank_points = (
-            jnp.zeros_like(s.round_state.score).at[order].set(s.round_state.order_points)
-        )  # Assign the rank points
-        score = s.round_state.score + rank_points  # Add the rank points
-        top = jnp.argmax(score)
-        final_score = score.at[top].add(
-            10 * s.round_state.kyotaku
-        )  # Add the Kyotaku (10 points per Riichi stick × number of Honba) to the top
+            is_tempai[dealer] & ~has_other_than_dealer_won, hora[dealer]
+        ) & ~(s.round_state.honba >= 8)
+        final_score = _final_score(s.round_state)
 
-        # Check if the round is ended
-        is_final_round = s.round_state.round == s.round_state.round_limit
-        has_dealer_end = jnp.logical_not(will_dealer_continue)
-        is_dealer_top = jnp.arange(4)[top] == s.round_state.dealer
-        has_minus_score = (s.round_state.score < 0).any()
-        _is_game_end = (
-            (is_final_round & has_dealer_end)
-            | (has_minus_score)
-            | (is_final_round & is_dealer_top)
-        )
+        game_end = _is_game_end(s.round_state, will_dealer_continue)
         return _replace_state(s, 
             current_player=jnp.int8((s.current_player + 1) % 4),
-            terminated=(s.round_state.dummy_count == 0) & _is_game_end,
+            terminated=(s.round_state.dummy_count == 0) & game_end,
             dummy_count=jnp.int8(
                 s.round_state.dummy_count + jnp.int8(1)
             ),  # Strictly set the dtype
             score=jnp.where(
-                (s.round_state.dummy_count == 0) & _is_game_end, final_score, s.round_state.score
+                (s.round_state.dummy_count == 0) & game_end, final_score, s.round_state.score
             ),  # Reflect the final score in the first DUMMY sharing phase
         )
 
@@ -1843,26 +1863,10 @@ def _next_round(state: State, key: PRNGKey) -> State:
             terminated=TRUE,
         )
 
-        # Check if the round is ended
-        top = jnp.argmax(s.round_state.score)
-        is_final_round = s.round_state.round == s.round_state.round_limit
-        has_dealer_end = jnp.logical_not(
-            will_dealer_continue
-        )  # Check if the dealer continues (win or temporary win)
-        is_dealer_top = (
-            jnp.arange(4)[top] == s.round_state.dealer
-        )  # Check if the dealer is the top
-        has_minus_score = (
-            s.round_state.score < 0
-        ).any()  # Check if there is a player with negative score
-        _is_game_end = (
-            (is_final_round & has_dealer_end)
-            | (has_minus_score)
-            | (is_final_round & is_dealer_top)
-        )
+        game_end = _is_game_end(s.round_state, will_dealer_continue)
         # Determine the next round or end the game
         return jax.lax.cond(
-            _is_game_end,
+            game_end,
             lambda: _replace_state(terminated_state, 
                 current_player=jnp.int8(terminated_state.round_state.dealer),
                 dummy_count=jnp.int8(0),
@@ -1897,14 +1901,7 @@ def _advance_to_next_round_auto(state: State, key: PRNGKey) -> State:
     is_tempai = state.players.can_win.any(axis=-1)  # (4,)
     dealer = state.round_state.dealer
 
-    # Final score = score + rank_points + kyotaku bonus on top
-    order = jnp.argsort(-state.round_state.score)
-    rank_points = (
-        jnp.zeros_like(state.round_state.score).at[order].set(state.round_state.order_points)
-    )
-    score_with_rank = state.round_state.score + rank_points
-    top_after_rank = jnp.argmax(score_with_rank)
-    final_score = score_with_rank.at[top_after_rank].add(10 * state.round_state.kyotaku)
+    final_score = _final_score(state.round_state)
 
     # Round-end / game-end conditions (matches _rotate_once + _finalize_and_start_next)
     is_eight_consecutive_deals = state.round_state.honba >= 8
@@ -1913,16 +1910,7 @@ def _advance_to_next_round_auto(state: State, key: PRNGKey) -> State:
         is_tempai[dealer] & ~has_other_than_dealer_won, hora[dealer]
     ) & ~is_eight_consecutive_deals
 
-    top_pre_rank = jnp.argmax(state.round_state.score)
-    is_final_round = state.round_state.round == state.round_state.round_limit
-    has_dealer_end = jnp.logical_not(will_dealer_continue)
-    is_dealer_top = jnp.arange(4)[top_pre_rank] == state.round_state.dealer
-    has_minus_score = (state.round_state.score < 0).any()
-    _is_game_end = (
-        (is_final_round & has_dealer_end)
-        | has_minus_score
-        | (is_final_round & is_dealer_top)
-    )
+    game_end = _is_game_end(state.round_state, will_dealer_continue)
 
     # Next round details
     next_round = jnp.where(will_dealer_continue, state.round_state.round, state.round_state.round + 1)
@@ -1956,7 +1944,7 @@ def _advance_to_next_round_auto(state: State, key: PRNGKey) -> State:
     )
 
     return jax.lax.cond(
-        _is_game_end,
+        game_end,
         lambda: terminated_state,
         lambda: next_round_state,
     )

--- a/mahjax/no_red_mahjong/env.py
+++ b/mahjax/no_red_mahjong/env.py
@@ -1765,7 +1765,7 @@ def _is_game_end(round_state, will_dealer_continue: Array) -> Array:
     ``round`` is 0-based and ``round_limit`` is the index of the last regular
     kyoku, so a half game ends after South-4 (``round_limit == 7``). If nobody
     has reached ``TARGET_SCORE`` there, the deal runs on into the extra rounds
-    (西入り) and ends as soon as someone does, or unconditionally once the last
+    (西入) and ends as soon as someone does, or unconditionally once the last
     extra round has been played.
     """
     score = round_state.score

--- a/mahjax/no_red_mahjong/env.py
+++ b/mahjax/no_red_mahjong/env.py
@@ -214,11 +214,11 @@ class NoRedMahjong(Env):
         round_mode: Literal["single", "east", "half"] = "half",
         observe_type: str = "dict",
         order_points: List[int] = [
-            30,
-            10,
-            -10,
-            -30,
-        ],  # No oka, 10-30, SAIKOUISEN rule https://saikouisen.com/about/rules/
+            300,
+            100,
+            -100,
+            -300,
+        ],  # No oka, 10-30 uma in hundreds of points like ``score``, SAIKOUISEN rule https://saikouisen.com/about/rules/
         next_round_style: Literal["auto", "dummy_share"] = "auto",
     ):
         if round_mode not in ("single", "east", "half"):
@@ -1748,13 +1748,9 @@ def _abortive_draw_normal(state: State) -> State:
 
 
 def _final_score(round_state) -> Array:
-    """Score at game end: raw score plus uma, with the riichi sticks to the top.
-
-    ``order_points`` is expressed in units of 1000 points and ``score`` in units
-    of 100, hence the factor of 10.
-    """
+    """Score at game end: raw score plus uma, with the riichi sticks to the top."""
     order = jnp.argsort(-round_state.score)
-    rank_points = jnp.zeros_like(round_state.score).at[order].set(round_state.order_points * 10)
+    rank_points = jnp.zeros_like(round_state.score).at[order].set(round_state.order_points)
     score = round_state.score + rank_points
     return score.at[jnp.argmax(score)].add(10 * round_state.kyotaku)
 

--- a/mahjax/no_red_mahjong/observation.py
+++ b/mahjax/no_red_mahjong/observation.py
@@ -97,10 +97,11 @@ def _observe_dict(state: State) -> Dict:
       rule. Gates riichi legality and menzen tsumo.
     - tiles_seen: (34,) int8, copies of each tile type already visible, [0, 4]
     - round / honba / kyotaku: () int8
-    - round_limit: () int8, last kyoku index of the game
+    - round_limit: () int8, last REGULAR kyoku index of the game; ``round`` runs
+      past it, up to ``round_limit + SUDDEN_DEATH_ROUNDS``, during sudden death
     - wall_remaining: () int32, drawable tiles left in the live wall, [0, 70]
-    - prevalent_wind: () int8, round // 4. Reaches 2 (West) on the last kyoku of a
-      'half' game, not just {0 East, 1 South}.
+    - prevalent_wind: () int8, round // 4. Reaches 2 (West) during the sudden-death
+      kyoku of a 'half' game, not just {0 East, 1 South}.
     - seat_wind: () int8, the current player's seat wind [0-3]; 0 is the dealer.
     - dora_indicators: (5,) int8, [0-33], -1 for unrevealed slots
     - target: () int8, the tile the pending call/ron decision is about, -1 when

--- a/mahjax/no_red_mahjong/state.py
+++ b/mahjax/no_red_mahjong/state.py
@@ -126,7 +126,7 @@ class RoundState:
     init_wind: Array = jnp.array([0, 1, 2, 3], dtype=jnp.int8)
     seat_wind: Array = jnp.array([0, 1, 2, 3], dtype=jnp.int8)
     dealer: Array = jnp.int8(0)
-    order_points: Array = jnp.array([30, 10, -10, -30], dtype=jnp.int32)
+    order_points: Array = jnp.array([300, 100, -100, -300], dtype=jnp.int32)
     score: Array = jnp.full((NUM_PLAYERS,), 250, dtype=jnp.int32)
     deck: Array = jnp.zeros((NUM_PHYSICAL_TILES,), dtype=jnp.int8)
     next_deck_ix: Array = jnp.int32(FIRST_DRAW_IDX)

--- a/mahjax/red_mahjong/constants.py
+++ b/mahjax/red_mahjong/constants.py
@@ -33,6 +33,10 @@ SENTINEL_DISCARD_VALUE: Final[int] = -1
 NO_WINNER_NONE: Final[int] = 0
 NO_WINNER_NORMAL: Final[int] = 1
 
+# ``score`` is in units of 100 points, ``TARGET_POINTS`` in points.
+TARGET_SCORE: Final[int] = TARGET_POINTS // 100
+SUDDEN_DEATH_ROUNDS: Final[int] = 4
+
 LEGAL_ACTION_SIZE: Final[int] = Action.NUM_ACTION
 
 FALSE = jnp.bool_(False)

--- a/mahjax/red_mahjong/env.py
+++ b/mahjax/red_mahjong/env.py
@@ -2108,7 +2108,7 @@ def _is_game_end(round_state, will_dealer_continue: Array) -> Array:
     ``round`` is 0-based and ``round_limit`` is the index of the last regular
     kyoku, so a half game ends after South-4 (``round_limit == 7``). If nobody
     has reached ``TARGET_SCORE`` there, the deal runs on into the extra rounds
-    (西入り) and ends as soon as someone does, or unconditionally once the last
+    (西入) and ends as soon as someone does, or unconditionally once the last
     extra round has been played.
     """
     score = round_state.score

--- a/mahjax/red_mahjong/env.py
+++ b/mahjax/red_mahjong/env.py
@@ -259,11 +259,11 @@ class RedMahjong(Env):
         round_mode: Literal["single", "east", "half"] = "half",
         observe_type: str = "dict",
         order_points: List[int] = [
-            30,
-            10,
-            -10,
-            -30,
-        ],  # No oka, 10-30, SAIKOUISEN rule https://saikouisen.com/about/rules/
+            300,
+            100,
+            -100,
+            -300,
+        ],  # No oka, 10-30 uma in hundreds of points like ``score``, SAIKOUISEN rule https://saikouisen.com/about/rules/
         game_config: Optional[GameConfig] = None,
         next_round_style: Literal["auto", "dummy_share"] = "auto",
     ):
@@ -2091,13 +2091,9 @@ def _mangan_tsumo(winner: Array, dealer: Array, honba: Array) -> Array:
 
 
 def _final_score(round_state) -> Array:
-    """Score at game end: raw score plus uma, with the riichi sticks to the top.
-
-    ``order_points`` is expressed in units of 1000 points and ``score`` in units
-    of 100, hence the factor of 10.
-    """
+    """Score at game end: raw score plus uma, with the riichi sticks to the top."""
     order = jnp.argsort(-round_state.score)
-    rank_points = jnp.zeros_like(round_state.score).at[order].set(round_state.order_points * 10)
+    rank_points = jnp.zeros_like(round_state.score).at[order].set(round_state.order_points)
     score = round_state.score + rank_points
     return score.at[jnp.argmax(score)].add(10 * round_state.kyotaku)
 

--- a/mahjax/red_mahjong/env.py
+++ b/mahjax/red_mahjong/env.py
@@ -21,7 +21,8 @@ import jax.numpy as jnp
 from mahjax.core import Env
 
 from .action import Action
-from .constants import DORA_ARRAY, FALSE, FIRST_DRAW_IDX, TILE_RANGE, TRUE, ZERO_MASK_1D, ZERO_MASK_2D
+from .constants import (DORA_ARRAY, FALSE, FIRST_DRAW_IDX, SUDDEN_DEATH_ROUNDS, TARGET_SCORE,
+                        TILE_RANGE, TRUE, ZERO_MASK_1D, ZERO_MASK_2D)
 from .hand import Hand
 from .meld import Meld
 from .shanten import Shanten
@@ -276,7 +277,7 @@ class RedMahjong(Env):
             )
         self.round_mode = round_mode
         self.one_round = round_mode == "single"
-        self.round_limit = jnp.int8(4 if round_mode == "east" else 8)
+        self.round_limit = jnp.int8(3 if round_mode == "east" else 7)
         self.observe_func = _observe_dict if observe_type == "dict" else _observe_2D
         self.observe_privileged_func = _observe_privileged_dict if observe_type == "dict" else _observe_privileged_2D
         self.order_points = order_points
@@ -2089,6 +2090,39 @@ def _mangan_tsumo(winner: Array, dealer: Array, honba: Array) -> Array:
     )
 
 
+def _final_score(round_state) -> Array:
+    """Score at game end: raw score plus uma, with the riichi sticks to the top.
+
+    ``order_points`` is expressed in units of 1000 points and ``score`` in units
+    of 100, hence the factor of 10.
+    """
+    order = jnp.argsort(-round_state.score)
+    rank_points = jnp.zeros_like(round_state.score).at[order].set(round_state.order_points * 10)
+    score = round_state.score + rank_points
+    return score.at[jnp.argmax(score)].add(10 * round_state.kyotaku)
+
+
+def _is_game_end(round_state, will_dealer_continue: Array) -> Array:
+    """Whether the hanchan/tonpuusen is over now that a kyoku has ended.
+
+    ``round`` is 0-based and ``round_limit`` is the index of the last regular
+    kyoku, so a half game ends after South-4 (``round_limit == 7``). If nobody
+    has reached ``TARGET_SCORE`` there, the deal runs on into the extra rounds
+    (西入り) and ends as soon as someone does, or unconditionally once the last
+    extra round has been played.
+    """
+    score = round_state.score
+    is_final_round = round_state.round >= round_state.round_limit
+    is_last_extra_round = round_state.round >= round_state.round_limit + SUDDEN_DEATH_ROUNDS
+    # The deal leaves the current dealer, or it stays but they are top and stop.
+    deal_passes = ~will_dealer_continue | (jnp.argmax(score) == round_state.dealer)
+    return (
+        (score < 0).any()
+        | is_last_extra_round
+        | (is_final_round & deal_passes & (score.max() >= TARGET_SCORE))
+    )
+
+
 def _next_round(
     state: State,
     key: PRNGKey,
@@ -2113,39 +2147,21 @@ def _next_round(
         is_tempai = s.players.can_win.any(axis=-1)  # (4,)
         dealer = s.round_state.dealer
         hora = s.players.has_won  # (4,)
+        has_other_than_dealer_won = hora.any() & ~hora[dealer]
         will_dealer_continue = jnp.logical_or(
-            is_tempai[dealer], hora[dealer]
-        )  # Check if the dealer continues (win or temporary win)
-        order = jnp.argsort(
-            -s.round_state.score
-        )  # Example: score=[10,20,30,40] -> order=[3,2,1,0]
-        rank_points = (
-            jnp.zeros_like(s.round_state.score).at[order].set(s.round_state.order_points)
-        )  # Assign the rank points
-        score = s.round_state.score + rank_points  # Add the rank points
-        top = jnp.argmax(score)
-        final_score = score.at[top].add(
-            10 * s.round_state.kyotaku
-        )  # Add the Kyotaku (10 points per Riichi stick × number of Honba) to the top
+            is_tempai[dealer] & ~has_other_than_dealer_won, hora[dealer]
+        ) & ~(s.round_state.honba >= 8)
+        final_score = _final_score(s.round_state)
 
-        # Check if the round is ended
-        is_final_round = s.round_state.round == s.round_state.round_limit
-        has_dealer_end = jnp.logical_not(will_dealer_continue)
-        is_dealer_top = jnp.arange(4)[top] == s.round_state.dealer
-        has_minus_score = (s.round_state.score < 0).any()
-        _is_game_end = (
-            (is_final_round & has_dealer_end)
-            | (has_minus_score)
-            | (is_final_round & is_dealer_top)
-        )
+        game_end = _is_game_end(s.round_state, will_dealer_continue)
         return _replace_state(s, 
             current_player=jnp.int8((s.current_player + 1) % 4),
-            terminated=(s.round_state.dummy_count == 0) & _is_game_end,
+            terminated=(s.round_state.dummy_count == 0) & game_end,
             dummy_count=jnp.int8(
                 s.round_state.dummy_count + jnp.int8(1)
             ),  # Strictly set the dtype
             score=jnp.where(
-                (s.round_state.dummy_count == 0) & _is_game_end, final_score, s.round_state.score
+                (s.round_state.dummy_count == 0) & game_end, final_score, s.round_state.score
             ),  # Reflect the final score in the first DUMMY sharing phase
         )
 
@@ -2199,26 +2215,10 @@ def _next_round(
             terminated=TRUE,
         )
 
-        # Check if the round is ended
-        top = jnp.argmax(s.round_state.score)
-        is_final_round = s.round_state.round == s.round_state.round_limit
-        has_dealer_end = jnp.logical_not(
-            will_dealer_continue
-        )  # Check if the dealer continues (win or temporary win)
-        is_dealer_top = (
-            jnp.arange(4)[top] == s.round_state.dealer
-        )  # Check if the dealer is the top
-        has_minus_score = (
-            s.round_state.score < 0
-        ).any()  # Check if there is a player with negative score
-        _is_game_end = (
-            (is_final_round & has_dealer_end)
-            | (has_minus_score)
-            | (is_final_round & is_dealer_top)
-        )
+        game_end = _is_game_end(s.round_state, will_dealer_continue)
         # Determine the next round or end the game
         return jax.lax.cond(
-            _is_game_end,
+            game_end,
             lambda: _replace_state(terminated_state, 
                 current_player=jnp.int8(terminated_state.round_state.dealer),
                 dummy_count=jnp.int8(0),
@@ -2255,13 +2255,7 @@ def _advance_to_next_round_auto(
     is_tempai = state.players.can_win.any(axis=-1)  # (4,)
     dealer = state.round_state.dealer
 
-    order = jnp.argsort(-state.round_state.score)
-    rank_points = (
-        jnp.zeros_like(state.round_state.score).at[order].set(state.round_state.order_points)
-    )
-    score_with_rank = state.round_state.score + rank_points
-    top_after_rank = jnp.argmax(score_with_rank)
-    final_score = score_with_rank.at[top_after_rank].add(10 * state.round_state.kyotaku)
+    final_score = _final_score(state.round_state)
 
     is_eight_consecutive_deals = state.round_state.honba >= 8
     has_other_than_dealer_won = hora.any() & ~hora[dealer]
@@ -2269,16 +2263,7 @@ def _advance_to_next_round_auto(
         is_tempai[dealer] & ~has_other_than_dealer_won, hora[dealer]
     ) & ~is_eight_consecutive_deals
 
-    top_pre_rank = jnp.argmax(state.round_state.score)
-    is_final_round = state.round_state.round == state.round_state.round_limit
-    has_dealer_end = jnp.logical_not(will_dealer_continue)
-    is_dealer_top = jnp.arange(4)[top_pre_rank] == state.round_state.dealer
-    has_minus_score = (state.round_state.score < 0).any()
-    _is_game_end = (
-        (is_final_round & has_dealer_end)
-        | has_minus_score
-        | (is_final_round & is_dealer_top)
-    )
+    game_end = _is_game_end(state.round_state, will_dealer_continue)
 
     next_round = jnp.where(will_dealer_continue, state.round_state.round, state.round_state.round + 1)
     has_winner = hora.any()
@@ -2312,7 +2297,7 @@ def _advance_to_next_round_auto(
     )
 
     return jax.lax.cond(
-        _is_game_end,
+        game_end,
         lambda: terminated_state,
         lambda: next_round_state,
     )

--- a/mahjax/red_mahjong/observation.py
+++ b/mahjax/red_mahjong/observation.py
@@ -126,16 +126,17 @@ def _observe_dict(state: State) -> Dict:
     GLOBAL -- table context that is not about any one tile or event.
     - scores: (4,) int32, scores ordered from the current player's seat
       (me, right, across, left)
-    - round: () int8, the kyoku counter in [0, round_limit]. ``RedMahjong`` sets
-      round_limit to 4 for 'east' and 8 for 'single'/'half', so the widest range is
-      [0, 8] -- not the [0, 12] an older docstring claimed.
-    - round_limit: () int8, last kyoku index of the game: 4 for 'east', 8 for
-      'single'/'half'. With ``round`` it gives how much game is left.
+    - round: () int8, the kyoku counter. ``RedMahjong`` sets round_limit to 3 for
+      'east' and 7 for 'single'/'half', and sudden death lets ``round`` run up to
+      ``round_limit + SUDDEN_DEATH_ROUNDS``, so the widest range is [0, 11].
+    - round_limit: () int8, last REGULAR kyoku index of the game: 3 for 'east', 7
+      for 'single'/'half'. With ``round`` it gives how much game is left, and
+      ``round > round_limit`` means the game is in sudden death.
     - honba: () int8
     - kyotaku: () int8
     - prevalent_wind: () int8, the round wind, round // 4. Reaches 2 (West), not
-      just {0 East, 1 South}: ``round`` runs to ``round_limit`` == 8 for
-      'single'/'half', and 8 // 4 == 2 on that last kyoku.
+      just {0 East, 1 South}: sudden death runs ``round`` past ``round_limit``,
+      and 8 // 4 == 2 on the first of those kyoku.
     - seat_wind: () int8, the current player's seat wind [0-3]; 0 is the dealer
     - dora_indicators: (MAX_DORA_INDICATORS,) int8, indicators [0-36] (red-aware),
       -1 for slots not yet revealed

--- a/mahjax/red_mahjong/state.py
+++ b/mahjax/red_mahjong/state.py
@@ -104,7 +104,7 @@ class RoundState:
     init_wind: jnp.ndarray = jnp.array([0, 1, 2, 3], dtype=jnp.int8)
     seat_wind: jnp.ndarray = jnp.array([0, 1, 2, 3], dtype=jnp.int8)
     dealer: jnp.int8 = jnp.int8(0)
-    order_points: jnp.ndarray = jnp.array([30, 10, -10, -30], dtype=jnp.int32)
+    order_points: jnp.ndarray = jnp.array([300, 100, -100, -300], dtype=jnp.int32)
     score: jnp.ndarray = jnp.full((NUM_PLAYERS,), 250, dtype=jnp.int32)
     deck: jnp.ndarray = jnp.zeros((NUM_PHYSICAL_TILES,), dtype=jnp.int8)
     next_deck_ix: jnp.int32 = jnp.int32(83)

--- a/tests/no_red_mahjong/test_env.py
+++ b/tests/no_red_mahjong/test_env.py
@@ -1621,7 +1621,7 @@ def test_no_red_sudden_death_runs_for_exactly_four_extra_rounds() -> None:
     assert terminated == [False, False, False, False, True]
 
 
-def test_no_red_uma_is_applied_in_units_of_1000_points() -> None:
+def test_no_red_uma_is_added_to_the_final_score() -> None:
     env = NoRedMahjong(round_mode="half", next_round_style="auto")
     before = jnp.array([310, 300, 200, 190], dtype=jnp.int32)
     state = _no_red_end_of_round_state(env, score=before)
@@ -1650,7 +1650,7 @@ def test_no_red_dummy_share_applies_uma_when_a_non_dealer_won_the_final_round() 
 
 
 def test_no_red_uma_scales_a_custom_order_points() -> None:
-    env = NoRedMahjong(round_mode="half", next_round_style="auto", order_points=[20, 5, -5, -20])
+    env = NoRedMahjong(round_mode="half", next_round_style="auto", order_points=[200, 50, -50, -200])
     before = jnp.array([310, 300, 200, 190], dtype=jnp.int32)
     state = _no_red_end_of_round_state(env, score=before)
 

--- a/tests/no_red_mahjong/test_env.py
+++ b/tests/no_red_mahjong/test_env.py
@@ -35,6 +35,7 @@ from mahjax.no_red_mahjong.env import (
     _next_round,
     _kan,
     NoRedMahjong,
+    _advance_to_next_round_auto,
     _replace_state,
 )
 
@@ -1149,7 +1150,7 @@ class TestEnv(unittest.TestCase):
         state = _advance_after_dummy(state)
         self.assertTrue(state.terminated)
         self.assertTrue(
-            jnp.all(state.round_state.score == jnp.array([370, 320, 180, 160], dtype=jnp.int32)),
+            jnp.all(state.round_state.score == jnp.array([640, 410, 90, -110], dtype=jnp.int32)),
             f"{state.round_state.score}",
         )
 
@@ -1339,7 +1340,7 @@ class TestNextRoundStyle(unittest.TestCase):
         self.assertTrue(bool(next_state.terminated))
         # Score reflects rank_points + kyotaku on top, matching the legacy
         # round_end_share final-score computation.
-        expected = jnp.array([370, 320, 180, 160], dtype=jnp.int32)
+        expected = jnp.array([640, 410, 90, -110], dtype=jnp.int32)
         # ``rewards`` from the RON itself were [0, 0, 0, 0] in this stub setup,
         # so the final score should equal expected (score + rank_points + kyotaku).
         self.assertTrue(
@@ -1546,3 +1547,113 @@ def test_open_kan_derives_the_tile_from_target_not_the_action_id() -> None:
         "open kan took the robbing-a-kan branch -- tile was derived from the action id"
     )
 
+
+
+def _no_red_end_of_round_state(env, **overrides):
+    state = env.init(jax.random.PRNGKey(7))
+    mask = jnp.zeros_like(state.players.legal_action_mask).at[:, Action.DUMMY].set(True)
+    fields = dict(
+        dealer=jnp.int8(0),
+        current_player=jnp.int8(0),
+        round=jnp.int8(7),
+        round_limit=jnp.int8(7),
+        honba=jnp.int8(0),
+        kyotaku=jnp.int8(0),
+        dummy_count=jnp.int8(0),
+        has_won=jnp.zeros(4, dtype=jnp.bool_),
+        can_win=jnp.zeros_like(state.players.can_win),
+        terminated_round=True,
+        draw_next=False,
+        legal_action_mask=mask,
+    )
+    fields.update(overrides)
+    return _replace_state(state, **fields)
+
+
+def test_no_red_half_game_is_eight_kyoku_long() -> None:
+    assert int(NoRedMahjong(round_mode="half").round_limit) == 7
+    assert int(NoRedMahjong(round_mode="east").round_limit) == 3
+
+
+def test_no_red_final_round_ends_the_game_once_someone_has_30000() -> None:
+    env = NoRedMahjong(round_mode="half", next_round_style="auto")
+    state = _no_red_end_of_round_state(env, score=jnp.array([300, 250, 240, 210], dtype=jnp.int32))
+
+    out = _advance_to_next_round_auto(state, jax.random.PRNGKey(0))
+
+    assert bool(out.terminated)
+
+
+def test_no_red_final_round_runs_on_when_nobody_has_30000() -> None:
+    env = NoRedMahjong(round_mode="half", next_round_style="auto")
+    state = _no_red_end_of_round_state(env, score=jnp.array([280, 250, 240, 230], dtype=jnp.int32))
+
+    out = _advance_to_next_round_auto(state, jax.random.PRNGKey(0))
+
+    assert not bool(out.terminated)
+    assert int(out.round_state.round) == 8
+
+
+def test_no_red_sudden_death_ends_at_the_last_extra_round() -> None:
+    env = NoRedMahjong(round_mode="half", next_round_style="auto")
+    state = _no_red_end_of_round_state(
+        env, round=jnp.int8(11), score=jnp.array([280, 250, 240, 230], dtype=jnp.int32)
+    )
+
+    out = _advance_to_next_round_auto(state, jax.random.PRNGKey(0))
+
+    assert bool(out.terminated)
+
+
+def test_no_red_sudden_death_runs_for_exactly_four_extra_rounds() -> None:
+    env = NoRedMahjong(round_mode="half", next_round_style="auto")
+    below = jnp.array([280, 250, 240, 230], dtype=jnp.int32)
+    terminated = [
+        bool(
+            _advance_to_next_round_auto(
+                _no_red_end_of_round_state(env, round=jnp.int8(r), score=below),
+                jax.random.PRNGKey(0),
+            ).terminated
+        )
+        for r in range(7, 12)
+    ]
+
+    assert terminated == [False, False, False, False, True]
+
+
+def test_no_red_uma_is_applied_in_units_of_1000_points() -> None:
+    env = NoRedMahjong(round_mode="half", next_round_style="auto")
+    before = jnp.array([310, 300, 200, 190], dtype=jnp.int32)
+    state = _no_red_end_of_round_state(env, score=before)
+
+    out = _advance_to_next_round_auto(state, jax.random.PRNGKey(0))
+
+    assert bool(out.terminated)
+    assert jnp.array_equal(out.round_state.score - before, jnp.array([300, 100, -100, -300]))
+
+
+def test_no_red_dummy_share_applies_uma_when_a_non_dealer_won_the_final_round() -> None:
+    env = NoRedMahjong(round_mode="half", next_round_style="dummy_share")
+    base = env.init(jax.random.PRNGKey(7))
+    state = _no_red_end_of_round_state(
+        env,
+        score=jnp.array([200, 300, 260, 240], dtype=jnp.int32),
+        kyotaku=jnp.int8(2),
+        has_won=jnp.zeros(4, dtype=jnp.bool_).at[1].set(True),
+        can_win=jnp.zeros_like(base.players.can_win).at[0, 0].set(True),
+    )
+
+    out = env.step(state, jnp.int32(Action.DUMMY), jax.random.PRNGKey(0))
+
+    assert bool(out.terminated)
+    assert jnp.array_equal(out.round_state.score, jnp.array([-100, 620, 360, 140]))
+
+
+def test_no_red_uma_scales_a_custom_order_points() -> None:
+    env = NoRedMahjong(round_mode="half", next_round_style="auto", order_points=[20, 5, -5, -20])
+    before = jnp.array([310, 300, 200, 190], dtype=jnp.int32)
+    state = _no_red_end_of_round_state(env, score=before)
+
+    out = _advance_to_next_round_auto(state, jax.random.PRNGKey(0))
+
+    assert jnp.array_equal(out.round_state.score - before, jnp.array([200, 50, -50, -200]))

--- a/tests/red_mahjong/test_env.py
+++ b/tests/red_mahjong/test_env.py
@@ -13,6 +13,7 @@ from mahjax.red_mahjong.env import (
     _mask_for_chi,
     _next_meld_player,
     _next_ron_player,
+    _advance_to_next_round_auto,
     _replace_state,
     _step,
 )
@@ -378,7 +379,7 @@ def test_red_auto_game_end_sets_terminated_with_final_score() -> None:
     )
     next_state = env_auto.step(state, jnp.int32(Action.RON), STEP_KEY)
     assert bool(next_state.terminated)
-    expected = jnp.array([370, 320, 180, 160], dtype=jnp.int32)
+    expected = jnp.array([640, 410, 90, -110], dtype=jnp.int32)
     assert bool(jnp.all(next_state.round_state.score == expected)), (
         f"got {next_state.round_state.score}, expected {expected}"
     )
@@ -499,3 +500,111 @@ def test_calc_wind_assigns_east_to_dealer() -> None:
     # The invariant the four literals encode.
     for dealer in range(4):
         assert int(_calc_wind(jnp.int32(dealer))[dealer]) == 0
+
+
+def _end_of_round_state(env, **overrides):
+    state = env.init(jax.random.PRNGKey(7))
+    mask = jnp.zeros_like(state.players.legal_action_mask).at[:, Action.DUMMY].set(True)
+    fields = dict(
+        dealer=jnp.int8(0),
+        current_player=jnp.int8(0),
+        round=jnp.int8(7),
+        round_limit=jnp.int8(7),
+        honba=jnp.int8(0),
+        kyotaku=jnp.int8(0),
+        dummy_count=jnp.int8(0),
+        has_won=jnp.zeros(4, dtype=jnp.bool_),
+        can_win=jnp.zeros_like(state.players.can_win),
+        terminated_round=True,
+        draw_next=False,
+        legal_action_mask=mask,
+    )
+    fields.update(overrides)
+    return _replace_state(state, **fields)
+
+
+def test_red_half_game_is_eight_kyoku_long() -> None:
+    assert int(RedMahjong(round_mode="half").round_limit) == 7
+    assert int(RedMahjong(round_mode="east").round_limit) == 3
+
+
+def test_red_final_round_ends_the_game_once_someone_has_30000() -> None:
+    env = RedMahjong(round_mode="half", next_round_style="auto")
+    state = _end_of_round_state(env, score=jnp.array([300, 250, 240, 210], dtype=jnp.int32))
+
+    out = _advance_to_next_round_auto(state, jax.random.PRNGKey(0))
+
+    assert bool(out.terminated)
+
+
+def test_red_final_round_runs_on_when_nobody_has_30000() -> None:
+    env = RedMahjong(round_mode="half", next_round_style="auto")
+    state = _end_of_round_state(env, score=jnp.array([280, 250, 240, 230], dtype=jnp.int32))
+
+    out = _advance_to_next_round_auto(state, jax.random.PRNGKey(0))
+
+    assert not bool(out.terminated)
+    assert int(out.round_state.round) == 8
+
+
+def test_red_sudden_death_ends_at_the_last_extra_round() -> None:
+    env = RedMahjong(round_mode="half", next_round_style="auto")
+    state = _end_of_round_state(
+        env, round=jnp.int8(11), score=jnp.array([280, 250, 240, 230], dtype=jnp.int32)
+    )
+
+    out = _advance_to_next_round_auto(state, jax.random.PRNGKey(0))
+
+    assert bool(out.terminated)
+
+
+def test_red_sudden_death_runs_for_exactly_four_extra_rounds() -> None:
+    env = RedMahjong(round_mode="half", next_round_style="auto")
+    below = jnp.array([280, 250, 240, 230], dtype=jnp.int32)
+    terminated = [
+        bool(
+            _advance_to_next_round_auto(
+                _end_of_round_state(env, round=jnp.int8(r), score=below), jax.random.PRNGKey(0)
+            ).terminated
+        )
+        for r in range(7, 12)
+    ]
+
+    assert terminated == [False, False, False, False, True]
+
+
+def test_red_uma_is_applied_in_units_of_1000_points() -> None:
+    env = RedMahjong(round_mode="half", next_round_style="auto")
+    before = jnp.array([310, 300, 200, 190], dtype=jnp.int32)
+    state = _end_of_round_state(env, score=before)
+
+    out = _advance_to_next_round_auto(state, jax.random.PRNGKey(0))
+
+    assert bool(out.terminated)
+    assert jnp.array_equal(out.round_state.score - before, jnp.array([300, 100, -100, -300]))
+
+
+def test_red_dummy_share_applies_uma_when_a_non_dealer_won_the_final_round() -> None:
+    env = RedMahjong(round_mode="half", next_round_style="dummy_share")
+    state = _end_of_round_state(
+        env,
+        score=jnp.array([200, 300, 260, 240], dtype=jnp.int32),
+        kyotaku=jnp.int8(2),
+        has_won=jnp.zeros(4, dtype=jnp.bool_).at[1].set(True),
+        can_win=jnp.zeros_like(env.init(jax.random.PRNGKey(7)).players.can_win).at[0, 0].set(True),
+    )
+
+    out = env.step(state, jnp.int8(Action.DUMMY), jax.random.PRNGKey(0))
+
+    assert bool(out.terminated)
+    assert jnp.array_equal(out.round_state.score, jnp.array([-100, 620, 360, 140]))
+
+
+def test_red_uma_scales_a_custom_order_points() -> None:
+    env = RedMahjong(round_mode="half", next_round_style="auto", order_points=[20, 5, -5, -20])
+    before = jnp.array([310, 300, 200, 190], dtype=jnp.int32)
+    state = _end_of_round_state(env, score=before)
+
+    out = _advance_to_next_round_auto(state, jax.random.PRNGKey(0))
+
+    assert jnp.array_equal(out.round_state.score - before, jnp.array([200, 50, -50, -200]))

--- a/tests/red_mahjong/test_env.py
+++ b/tests/red_mahjong/test_env.py
@@ -573,7 +573,7 @@ def test_red_sudden_death_runs_for_exactly_four_extra_rounds() -> None:
     assert terminated == [False, False, False, False, True]
 
 
-def test_red_uma_is_applied_in_units_of_1000_points() -> None:
+def test_red_uma_is_added_to_the_final_score() -> None:
     env = RedMahjong(round_mode="half", next_round_style="auto")
     before = jnp.array([310, 300, 200, 190], dtype=jnp.int32)
     state = _end_of_round_state(env, score=before)
@@ -601,7 +601,7 @@ def test_red_dummy_share_applies_uma_when_a_non_dealer_won_the_final_round() -> 
 
 
 def test_red_uma_scales_a_custom_order_points() -> None:
-    env = RedMahjong(round_mode="half", next_round_style="auto", order_points=[20, 5, -5, -20])
+    env = RedMahjong(round_mode="half", next_round_style="auto", order_points=[200, 50, -50, -200])
     before = jnp.array([310, 300, 200, 190], dtype=jnp.int32)
     state = _end_of_round_state(env, score=before)
 


### PR DESCRIPTION
## 1. Uma was a tenth of what it should be

`score` counts in hundreds of points, but `order_points` was written in thousands (`[30, 10, -10, -30]`) and added straight into it. First place got +3000 instead of +30000, in every game that finished.

`order_points` is now in hundreds of points, the same unit as `score`: `[300, 100, -100, -300]`. Nothing scales it any more.

**Breaking:** if you pass `order_points` yourself, multiply your values by 10.

## 2. A hanchan was nine kyoku, and there was no sudden death

`round` counts from zero and the game ends when `round == round_limit`, but `round_limit` was 8. A hanchan therefore ran East-1 all the way through West-1, one kyoku too many. It is now 7, and 3 for tonpuusen.

Sudden death (西入) is implemented on top. If nobody holds 30000 points when the last kyoku ends, play continues and stops the moment somebody reaches 30000, or after four extra kyoku. The threshold comes from `GameConfig.target_points`, which already existed for this and was never read.

## 3. dummy_share could lose the uma and the riichi sticks

The game-end check lived in three places, with two different rules for whether the dealer keeps the deal. The loose rule ran first and sometimes failed to notice the game was over. The strict rule then caught it one step later, on a path that writes the raw score with no uma and no riichi sticks. The two rules disagree on 31% of random kyoku endings.

The three copies are now a single `_is_game_end` per environment, and the two copies of the final-score calculation are a single `_final_score`. The duplication is what caused this bug, so removing it is the fix rather than tidying. The diff deletes more lines than it adds.

## Worth knowing before merging

Games get longer for a weak policy. It rarely gets anyone to 30000, so sudden death runs its full four kyoku. Measured with random play: tonpuusen 5 to 8 kyoku, hanchan 9 to 12. A policy that actually wins hands should usually finish at South-4.

Two things that look wrong but are deliberate:

- `_is_game_end` takes `argmax` on the raw score. The old dummy_share copy used the post-uma score instead, but uma never reorders the ranking, and across 5000 random score vectors the two never differed.
- `_finalize_and_start_next` still writes the raw score. Routing it through `_final_score` would apply uma a second time, because the earlier step already applied it. That branch is unreachable now that both rules agree.

## Tests

286 passed, 2 skipped. 16 new tests, 8 per environment, plus 3 updated expectations. 14 of the new tests and all 3 updates fail on `main`.

`tests/no_red_mahjong/test_play.py` fails the same way on `main` and is excluded from CI.

Checked by hand across both environments, both round modes and both next-round styles: random games always end, `round` never passes its cap, and the four scores always still add up to 100000.
