### PR TITLE
Fix(env): rewards now describe the step that just ran, and furiten by pass lasts a full go-around

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ env = mahjax.make(
     "red_mahjong",
     round_mode="single", # "single", "east" (tonpuusen), or "half" (hanchan)
     observe_type="dict", # "dict" for Transformer, "2D" for CNN
-    order_points=[300, 100, -100, -300], # Final score bonuses (uma), in hundreds of points
+    order_points=[0, 0, 0, 0], # Final score bonuses (uma), in hundreds of points
 )
 
 init_fn = jax.jit(jax.vmap(env.init))
@@ -155,14 +155,14 @@ You can configure the environment with:
 - `id`: the rule set, such as `red_mahjong` or `no_red_mahjong`
 - `round_mode`: `single` for a single round, `east` for tonpuusen (East-only), or `half` for hanchan (East-South)
 - `observe_type`: `dict` for transformer-style inputs or `2D` for CNN-style inputs
-- `order_points`: final placement bonuses (uma), in hundreds of points like `score`, for example `[300, 100, -100, -300]` for 10-30 uma
+- `order_points`: final placement bonuses (uma), in hundreds of points like `score`. Defaults to no uma; pass `[300, 100, -100, -300]` for 10-30 uma
 
 ```python
 env = mahjax.make(
     "red_mahjong",
     round_mode="single",
     observe_type="dict",
-    order_points=[300, 100, -100, -300],
+    order_points=[0, 0, 0, 0],
 )
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -24,7 +24,7 @@ env = mahjax.make(
     "red_mahjong",
     round_mode="single",   # "single", "east" (tonpuusen), or "half" (hanchan)
     next_round_style="auto",  # "auto" (default, RL) or "dummy_share" (interactive / mjai)
-    order_points=[300, 100, -100, -300],
+    order_points=[0, 0, 0, 0],
 )
 step_fn = jax.jit(jax.vmap(env.step))
 obs_fn = jax.jit(jax.vmap(env.observe))
@@ -111,7 +111,7 @@ Held common across all four players.
 | `init_wind` | `(4,)` | `int8` | Initial seat winds at the start of the game. |
 | `seat_wind` | `(4,)` | `int8` | Current seat wind per player. |
 | `dealer` | `()` | `int8` | Current dealer. |
-| `order_points` | `(4,)` | `int32` | Placement bonus / uma, in hundreds of points like `score`. |
+| `order_points` | `(4,)` | `int32` | Placement bonus / uma, in hundreds of points like `score`. Defaults to all zeros. |
 | `score` | `(4,)` | `int32` | Per-player score, in hundreds of points. |
 | `deck` | `(136,)` | `int8` | Current round's shuffled wall (tile types). |
 | `next_deck_ix` | `()` | `int32` | Next index to draw from in `deck`. |

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,7 @@ env = mahjax.make(
     "red_mahjong",
     round_mode="single", # "single", "east" (tonpuusen), or "half" (hanchan)
     observe_type="dict", # "dict" for Transformer, "2D" for CNN
-    order_points=[300, 100, -100, -300], # Final score bonuses (uma), in hundreds of points
+    order_points=[0, 0, 0, 0], # Final score bonuses (uma), in hundreds of points
 )
 
 init_fn = jax.jit(jax.vmap(env.init))
@@ -144,14 +144,14 @@ You can configure the environment with:
 - `id`: the rule set, such as `red_mahjong` or `no_red_mahjong`
 - `round_mode`: `single` for a single round, `east` for tonpuusen (East-only), or `half` for hanchan (East-South)
 - `observe_type`: `dict` for transformer-style inputs or `2D` for CNN-style inputs
-- `order_points`: final placement bonuses (uma), in hundreds of points like `score`, for example `[300, 100, -100, -300]` for 10-30 uma
+- `order_points`: final placement bonuses (uma), in hundreds of points like `score`. Defaults to no uma; pass `[300, 100, -100, -300]` for 10-30 uma
 
 ```python
 env = mahjax.make(
     "red_mahjong",
     round_mode="single",
     observe_type="dict",
-    order_points=[300, 100, -100, -300],
+    order_points=[0, 0, 0, 0],
 )
 ```
 

--- a/mahjax/core.py
+++ b/mahjax/core.py
@@ -264,7 +264,7 @@ def make(env_id: EnvId, **kwargs):  # noqa: C901
             "no_red_mahjong",
             round_mode="single",  # "single", "east" (tonpuusen), or "half" (hanchan)
             observe_type="dict", # "dict" for Transformer, "2D" for CNN
-            order_points=[300, 100, -100, -300],  # Final score bonuses (uma), in hundreds of points
+            order_points=[0, 0, 0, 0],  # Final score bonuses (uma), in hundreds of points
         )
         ```
     """

--- a/mahjax/no_red_mahjong/env.py
+++ b/mahjax/no_red_mahjong/env.py
@@ -214,11 +214,11 @@ class NoRedMahjong(Env):
         round_mode: Literal["single", "east", "half"] = "half",
         observe_type: str = "dict",
         order_points: List[int] = [
-            300,
-            100,
-            -100,
-            -300,
-        ],  # No oka, 10-30 uma in hundreds of points like ``score``, SAIKOUISEN rule https://saikouisen.com/about/rules/
+            0,
+            0,
+            0,
+            0,
+        ],  # No uma by default; in hundreds of points like ``score`` (10-30 uma is [300, 100, -100, -300])
         next_round_style: Literal["auto", "dummy_share"] = "auto",
     ):
         if round_mode not in ("single", "east", "half"):
@@ -272,6 +272,7 @@ class NoRedMahjong(Env):
         current_player = state.current_player
         state = _replace_state(state,   # type:ignore
             order_points=jnp.array(self.order_points, dtype=jnp.int32),
+            rewards=jnp.zeros_like(state.rewards),
         )  # type: ignore reflect the order points
 
         # If the state is already terminated or truncated, environment does not take usual step,
@@ -1519,7 +1520,7 @@ def _pass(state: State):
             ),  # If the player who declared the KAN passes, set the last player
             target=jnp.int8(-1),
             furiten_by_pass=state.players.furiten_by_pass.at[c_p].set(
-                is_ron_player & ~can_robbing_kan
+                state.players.furiten_by_pass[c_p] | (is_ron_player & ~can_robbing_kan)
             ),  # If the player who RON passes, set the furiten
             draw_next=TRUE
             & ~can_robbing_kan,  # If no next player for robbing KAN, draw the rinshan tile
@@ -1535,7 +1536,7 @@ def _pass(state: State):
                 TRUE
             ),  # Add the pass action to the legal action
             furiten_by_pass=state.players.furiten_by_pass.at[c_p].set(
-                is_ron_player & ~can_robbing_kan
+                state.players.furiten_by_pass[c_p] | (is_ron_player & ~can_robbing_kan)
             ),  # If the player who RON passes, set the furiten
         ),
     )
@@ -1808,6 +1809,11 @@ def _next_round(state: State, key: PRNGKey) -> State:
             score=jnp.where(
                 (s.round_state.dummy_count == 0) & game_end, final_score, s.round_state.score
             ),  # Reflect the final score in the first DUMMY sharing phase
+            rewards=jnp.where(
+                (s.round_state.dummy_count == 0) & game_end,
+                jnp.float32(final_score - s.round_state.score),
+                s.rewards,
+            ),
         )
 
     # ---- After the DUMMY sharing phase (=3), determine the next round or end the game ----
@@ -1936,6 +1942,7 @@ def _advance_to_next_round_auto(state: State, key: PRNGKey) -> State:
 
     terminated_state = _replace_state(state,
         score=jnp.int32(final_score),
+        rewards=jnp.float32(state.rewards + (final_score - state.round_state.score)),
         terminated=TRUE,
     )
 

--- a/mahjax/no_red_mahjong/env.py
+++ b/mahjax/no_red_mahjong/env.py
@@ -1373,6 +1373,20 @@ def _added_kan(state: State, target):
     )
 
 
+def _clear_furiten_by_pass(state: State, c_p: Array) -> State:
+    """Furiten by pass lasts only until the player's own turn comes round again.
+
+    ``_draw`` does this for a normal turn; a turn taken by pon / chi / open kan
+    has no draw, so those call it directly. Riichi keeps the player furiten.
+    """
+    return _replace_state(
+        state,
+        furiten_by_pass=state.players.furiten_by_pass.at[c_p].set(
+            state.players.furiten_by_pass[c_p] & state.players.riichi[c_p]
+        ),
+    )
+
+
 def _open_kan(state: State):
     """
     Apply OPEN_KAN
@@ -1382,6 +1396,7 @@ def _open_kan(state: State):
     c_p = state.current_player
     l_p = state.round_state.last_player
     state = _accept_riichi(state)
+    state = _clear_furiten_by_pass(state, c_p)
     src = (l_p - c_p) % 4
     meld = Meld.init(Action.OPEN_KAN, state.round_state.target, src)
     state = _append_meld(state, meld, c_p)
@@ -1409,6 +1424,7 @@ def _pon(state: State, action: Array):
     l_p = state.round_state.last_player
     tar = state.round_state.target
     state = _accept_riichi(state)
+    state = _clear_furiten_by_pass(state, c_p)
     src = (l_p - c_p) % 4
     meld = Meld.init(Action.PON, tar, src)
     state = _append_meld(state, meld, c_p)
@@ -1449,6 +1465,7 @@ def _chi(state: State, action: Array):
     tar_p = state.round_state.last_player  # Absolute position
     tar = state.round_state.target
     state = _accept_riichi(state)
+    state = _clear_furiten_by_pass(state, c_p)
     meld = Meld.init(action, tar, src=jnp.int32(3))
     state = _append_meld(state, meld, c_p)
     chi_hand = Hand.chi(state.players.hand[c_p], tar, action)

--- a/mahjax/no_red_mahjong/state.py
+++ b/mahjax/no_red_mahjong/state.py
@@ -126,7 +126,7 @@ class RoundState:
     init_wind: Array = jnp.array([0, 1, 2, 3], dtype=jnp.int8)
     seat_wind: Array = jnp.array([0, 1, 2, 3], dtype=jnp.int8)
     dealer: Array = jnp.int8(0)
-    order_points: Array = jnp.array([300, 100, -100, -300], dtype=jnp.int32)
+    order_points: Array = jnp.array([0, 0, 0, 0], dtype=jnp.int32)
     score: Array = jnp.full((NUM_PLAYERS,), 250, dtype=jnp.int32)
     deck: Array = jnp.zeros((NUM_PHYSICAL_TILES,), dtype=jnp.int8)
     next_deck_ix: Array = jnp.int32(FIRST_DRAW_IDX)
@@ -154,6 +154,8 @@ class EnvState:
     round_state: RoundState = RoundState()
     step_count: Array = jnp.int32(0)
     rewards: Array = jnp.zeros(NUM_PLAYERS, dtype=jnp.float32)
+    # Kept for schema parity with red_mahjong, which uses it for multi-ron.
+    pending_rewards: Array = jnp.zeros(NUM_PLAYERS, dtype=jnp.float32)
     terminated: Array = FALSE
     truncated: Array = FALSE
 

--- a/mahjax/red_mahjong/env.py
+++ b/mahjax/red_mahjong/env.py
@@ -1548,6 +1548,20 @@ def _added_kan(state: State, target):
     )
 
 
+def _clear_furiten_by_pass(state: State, c_p: Array) -> State:
+    """Furiten by pass lasts only until the player's own turn comes round again.
+
+    ``_draw`` does this for a normal turn; a turn taken by pon / chi / open kan
+    has no draw, so those call it directly. Riichi keeps the player furiten.
+    """
+    return _replace_state(
+        state,
+        furiten_by_pass=state.players.furiten_by_pass.at[c_p].set(
+            state.players.furiten_by_pass[c_p] & state.players.riichi[c_p]
+        ),
+    )
+
+
 def _open_kan(state: State):
     """
     Apply OPEN_KAN
@@ -1557,6 +1571,7 @@ def _open_kan(state: State):
     c_p = state.current_player
     l_p = state.round_state.last_player
     state = _accept_riichi(state)
+    state = _clear_furiten_by_pass(state, c_p)
     src = (l_p - c_p) % 4
     meld = Meld.init(Action.OPEN_KAN, state.round_state.target, src)
     state = _append_meld(state, meld, c_p)
@@ -1589,6 +1604,7 @@ def _pon(state: State, action: Array):
     l_p = state.round_state.last_player
     tar = state.round_state.target
     state = _accept_riichi(state)
+    state = _clear_furiten_by_pass(state, c_p)
     src = (l_p - c_p) % 4
     meld = Meld.init(action, tar, src)
     state = _append_meld(state, meld, c_p)
@@ -1631,6 +1647,7 @@ def _chi(state: State, action: Array):
     tar_p = state.round_state.last_player  # Absolute position
     tar = state.round_state.target
     state = _accept_riichi(state)
+    state = _clear_furiten_by_pass(state, c_p)
     meld = Meld.init(action, tar, src=jnp.int32(3))
     state = _append_meld(state, meld, c_p)
     chi_hand = Hand.chi(state.players.hand_with_red[c_p], tar, action)

--- a/mahjax/red_mahjong/env.py
+++ b/mahjax/red_mahjong/env.py
@@ -259,11 +259,11 @@ class RedMahjong(Env):
         round_mode: Literal["single", "east", "half"] = "half",
         observe_type: str = "dict",
         order_points: List[int] = [
-            300,
-            100,
-            -100,
-            -300,
-        ],  # No oka, 10-30 uma in hundreds of points like ``score``, SAIKOUISEN rule https://saikouisen.com/about/rules/
+            0,
+            0,
+            0,
+            0,
+        ],  # No uma by default; in hundreds of points like ``score`` (10-30 uma is [300, 100, -100, -300])
         game_config: Optional[GameConfig] = None,
         next_round_style: Literal["auto", "dummy_share"] = "auto",
     ):
@@ -322,6 +322,7 @@ class RedMahjong(Env):
         state = _replace_state(
             state,
             order_points=jnp.array(self.order_points, dtype=jnp.int32),
+            rewards=jnp.zeros_like(state.rewards),  # Reset rewards to 0 for this step
         )
 
 
@@ -1705,7 +1706,7 @@ def _pass(state: State, game_config: Optional[GameConfig] = None):
             current_player=jnp.int8(next_ron_player),
             legal_action_mask=post_ron_mask.at[next_ron_player, Action.PASS].set(TRUE),
             furiten_by_pass=state.players.furiten_by_pass.at[c_p].set(
-                is_ron_player & ~can_robbing_kan
+                state.players.furiten_by_pass[c_p] | (is_ron_player & ~can_robbing_kan)
             ),
             draw_next=FALSE,
         ),
@@ -1713,9 +1714,11 @@ def _pass(state: State, game_config: Optional[GameConfig] = None):
             state,
             target=jnp.int8(-1),
             furiten_by_pass=state.players.furiten_by_pass.at[c_p].set(
-                is_ron_player & ~can_robbing_kan
+                state.players.furiten_by_pass[c_p] | (is_ron_player & ~can_robbing_kan)
             ),
-            score=jnp.int32(state.round_state.score + state.rewards),
+            score=jnp.int32(state.round_state.score + state.pending_rewards),
+            rewards=jnp.float32(state.pending_rewards),
+            pending_rewards=jnp.zeros_like(state.rewards),
             kyotaku=jnp.int8(0),
             legal_action_mask=ZERO_MASK_2D.at[:, Action.DUMMY].set(TRUE),
             terminated_round=TRUE,
@@ -1736,7 +1739,7 @@ def _pass(state: State, game_config: Optional[GameConfig] = None):
                 ),
                 target=jnp.int8(-1),
                 furiten_by_pass=state.players.furiten_by_pass.at[c_p].set(
-                    is_ron_player & ~can_robbing_kan
+                    state.players.furiten_by_pass[c_p] | (is_ron_player & ~can_robbing_kan)
                 ),
                 draw_next=TRUE & ~can_robbing_kan,
                 is_abortive_draw_normal=is_abortive_draw_normal,
@@ -1749,7 +1752,7 @@ def _pass(state: State, game_config: Optional[GameConfig] = None):
                     next_meld_player, Action.PASS
                 ].set(TRUE),
                 furiten_by_pass=state.players.furiten_by_pass.at[c_p].set(
-                    is_ron_player & ~can_robbing_kan
+                    state.players.furiten_by_pass[c_p] | (is_ron_player & ~can_robbing_kan)
                 ),
             ),
         ),
@@ -1827,7 +1830,7 @@ def _ron(state: State, game_config: Optional[GameConfig] = None) -> State:
     # The Kyotaku is already paid when the RIICHI is declared, so we only need to add the Kyotaku to the winner
     kyotaku_bonus = 10 * state.round_state.kyotaku * is_first_ron
     reward = reward.at[c_p].add(kyotaku_bonus)
-    pending = jnp.where(is_first_ron, jnp.zeros_like(state.rewards), state.rewards) + reward
+    pending = jnp.where(is_first_ron, jnp.zeros_like(state.rewards), state.pending_rewards) + reward
     score = state.round_state.score + pending
     remaining_ron_mask = ZERO_MASK_2D.at[:, Action.RON].set(
         state.players.legal_action_mask[:, Action.RON]
@@ -1846,6 +1849,7 @@ def _ron(state: State, game_config: Optional[GameConfig] = None) -> State:
         _replace_state(
             state,
             rewards=jnp.zeros_like(state.rewards),
+            pending_rewards=jnp.zeros_like(state.rewards),
             has_won=jnp.zeros_like(state.players.has_won),
         )
     )
@@ -1857,7 +1861,7 @@ def _ron(state: State, game_config: Optional[GameConfig] = None) -> State:
     continue_state = _replace_state(
         state,
         current_player=jnp.int8(next_ron_player),
-        rewards=jnp.float32(pending),
+        pending_rewards=jnp.float32(pending),
         has_won=state.players.has_won.at[c_p].set(TRUE),
         legal_action_mask=remaining_ron_mask.at[next_ron_player, Action.PASS].set(TRUE),
         draw_next=FALSE,
@@ -1866,7 +1870,8 @@ def _ron(state: State, game_config: Optional[GameConfig] = None) -> State:
         state,
         terminated_round=TRUE,
         score=jnp.int32(score),
-        rewards=jnp.float32(reward),
+        rewards=jnp.float32(pending),
+        pending_rewards=jnp.zeros_like(state.rewards),
         kyotaku=jnp.int8(0),
         has_won=state.players.has_won.at[c_p].set(TRUE),
         legal_action_mask=ZERO_MASK_2D.at[:, Action.DUMMY].set(TRUE),
@@ -2159,6 +2164,11 @@ def _next_round(
             score=jnp.where(
                 (s.round_state.dummy_count == 0) & game_end, final_score, s.round_state.score
             ),  # Reflect the final score in the first DUMMY sharing phase
+            rewards=jnp.where(
+                (s.round_state.dummy_count == 0) & game_end,
+                jnp.float32(final_score - s.round_state.score),
+                s.rewards,
+            ),
         )
 
     # ---- After the DUMMY sharing phase (=3), determine the next round or end the game ----
@@ -2289,6 +2299,7 @@ def _advance_to_next_round_auto(
 
     terminated_state = _replace_state(state,
         score=jnp.int32(final_score),
+        rewards=jnp.float32(state.rewards + (final_score - state.round_state.score)),
         terminated=TRUE,
     )
 

--- a/mahjax/red_mahjong/state.py
+++ b/mahjax/red_mahjong/state.py
@@ -104,7 +104,7 @@ class RoundState:
     init_wind: jnp.ndarray = jnp.array([0, 1, 2, 3], dtype=jnp.int8)
     seat_wind: jnp.ndarray = jnp.array([0, 1, 2, 3], dtype=jnp.int8)
     dealer: jnp.int8 = jnp.int8(0)
-    order_points: jnp.ndarray = jnp.array([300, 100, -100, -300], dtype=jnp.int32)
+    order_points: jnp.ndarray = jnp.array([0, 0, 0, 0], dtype=jnp.int32)
     score: jnp.ndarray = jnp.full((NUM_PLAYERS,), 250, dtype=jnp.int32)
     deck: jnp.ndarray = jnp.zeros((NUM_PHYSICAL_TILES,), dtype=jnp.int8)
     next_deck_ix: jnp.int32 = jnp.int32(83)
@@ -132,6 +132,8 @@ class EnvState:
     round_state: RoundState = RoundState()
     step_count: jnp.int32 = jnp.int32(0)
     rewards: jnp.ndarray = jnp.zeros((NUM_PLAYERS,), dtype=jnp.float32)
+    # Multi-ron payments wait here until the ron chain resolves; see ``_ron``.
+    pending_rewards: jnp.ndarray = jnp.zeros((NUM_PLAYERS,), dtype=jnp.float32)
     terminated: jnp.bool_ = FALSE
     truncated: jnp.bool_ = FALSE
 

--- a/tests/no_red_mahjong/test_env.py
+++ b/tests/no_red_mahjong/test_env.py
@@ -1146,6 +1146,7 @@ class TestEnv(unittest.TestCase):
             round=jnp.int8(7),   # final round
             kyotaku=jnp.int8(3),
             dummy_count=jnp.int8(0),
+            order_points=jnp.array([300, 100, -100, -300], dtype=jnp.int32),
         )
         state = _advance_after_dummy(state)
         self.assertTrue(state.terminated)
@@ -1318,7 +1319,7 @@ class TestNextRoundStyle(unittest.TestCase):
     def test_auto_game_end_sets_terminated_with_final_score(self):
         # Final round (round == round_limit), dealer not top and no continuation
         # ⇒ game ends. Confirm score = score + rank_points + kyotaku bonus.
-        env_auto = NoRedMahjong(round_mode="half", next_round_style="auto")
+        env_auto = NoRedMahjong(round_mode="half", next_round_style="auto", order_points=[300, 100, -100, -300])
         state = env_auto.init(jax.random.PRNGKey(3))
         # Note: env.init overrides round_limit to 8 for half. Override it here
         # so that the test setup matches the legacy state-level convention used
@@ -1445,8 +1446,8 @@ class TestAutoDummyShareParity(unittest.TestCase):
         # terminates one step later (DUMMY 1 detects _is_game_end at dc==0).
         # Compare the two terminal states: same terminated, same final score,
         # same rewards.
-        env_auto = NoRedMahjong(round_mode="half", next_round_style="auto")
-        env_share = NoRedMahjong(round_mode="half", next_round_style="dummy_share")
+        env_auto = NoRedMahjong(round_mode="half", next_round_style="auto", order_points=[300, 100, -100, -300])
+        env_share = NoRedMahjong(round_mode="half", next_round_style="dummy_share", order_points=[300, 100, -100, -300])
         key = jax.random.PRNGKey(2026)
         forced = dict(
             dealer=jnp.int8(0),
@@ -1462,15 +1463,18 @@ class TestAutoDummyShareParity(unittest.TestCase):
         state_share = _replace_state(self._force_ron_state(env_share, key), **forced)
 
         state_auto = env_auto.step(state_auto, jnp.int32(Action.RON), STEP_KEY)
+        total_auto = state_auto.rewards
         state_share = env_share.step(state_share, jnp.int32(Action.RON), STEP_KEY)
+        total_share = state_share.rewards
         state_share = env_share.step(state_share, jnp.int32(Action.DUMMY), STEP_KEY)
+        total_share = total_share + state_share.rewards
 
         self.assertTrue(bool(state_auto.terminated))
         self.assertTrue(bool(state_share.terminated))
         self.assertTrue(
             bool(jnp.all(state_auto.round_state.score == state_share.round_state.score))
         )
-        self.assertTrue(bool(jnp.all(state_auto.rewards == state_share.rewards)))
+        self.assertTrue(bool(jnp.all(total_auto == total_share)))
 
 
 if __name__ == "__main__":
@@ -1622,7 +1626,7 @@ def test_no_red_sudden_death_runs_for_exactly_four_extra_rounds() -> None:
 
 
 def test_no_red_uma_is_added_to_the_final_score() -> None:
-    env = NoRedMahjong(round_mode="half", next_round_style="auto")
+    env = NoRedMahjong(round_mode="half", next_round_style="auto", order_points=[300, 100, -100, -300])
     before = jnp.array([310, 300, 200, 190], dtype=jnp.int32)
     state = _no_red_end_of_round_state(env, score=before)
 
@@ -1633,7 +1637,7 @@ def test_no_red_uma_is_added_to_the_final_score() -> None:
 
 
 def test_no_red_dummy_share_applies_uma_when_a_non_dealer_won_the_final_round() -> None:
-    env = NoRedMahjong(round_mode="half", next_round_style="dummy_share")
+    env = NoRedMahjong(round_mode="half", next_round_style="dummy_share", order_points=[300, 100, -100, -300])
     base = env.init(jax.random.PRNGKey(7))
     state = _no_red_end_of_round_state(
         env,
@@ -1657,3 +1661,69 @@ def test_no_red_uma_scales_a_custom_order_points() -> None:
     out = _advance_to_next_round_auto(state, jax.random.PRNGKey(0))
 
     assert jnp.array_equal(out.round_state.score - before, jnp.array([200, 50, -50, -200]))
+
+
+def _temporary_furiten_after_declining_then_an_unrelated_pass(m, Action):
+    """X declines a winning discard, then passes on an unrelated PON before drawing."""
+    base = m.default_state()
+    x = 1
+    mask = base.players.legal_action_mask
+    declined = m._pass(
+        m._replace_state(
+            base,
+            current_player=jnp.int8(x),
+            last_player=jnp.int8(0),
+            legal_action_mask=mask.at[x, Action.RON].set(True).at[x, Action.PASS].set(True),
+        )
+    )
+    unrelated = m._pass(
+        m._replace_state(
+            declined,
+            current_player=jnp.int8(x),
+            last_player=jnp.int8(2),
+            legal_action_mask=mask.at[x, Action.PON].set(True).at[x, Action.PASS].set(True),
+        )
+    )
+    return x, declined, unrelated
+
+
+def test_no_red_temporary_furiten_survives_an_unrelated_pass() -> None:
+    from mahjax.no_red_mahjong import env as m
+
+    x, declined, unrelated = _temporary_furiten_after_declining_then_an_unrelated_pass(m, Action)
+
+    assert bool(declined.players.furiten_by_pass[x])
+    assert bool(unrelated.players.furiten_by_pass[x])
+    drawn = _draw(_replace_state(unrelated, current_player=jnp.int8(x), draw_next=True))
+    assert not bool(drawn.players.furiten_by_pass[x])
+    riichi = _draw(
+        _replace_state(
+            unrelated,
+            current_player=jnp.int8(x),
+            draw_next=True,
+            riichi=unrelated.players.riichi.at[x].set(True),
+        )
+    )
+    assert bool(riichi.players.furiten_by_pass[x])
+
+
+def test_no_red_rewards_report_only_the_current_transition() -> None:
+    env = NoRedMahjong(round_mode="east", next_round_style="dummy_share")
+    step = jax.jit(env.step)
+    key = jax.random.PRNGKey(11)
+    key, sub = jax.random.split(key)
+    state = env.init(sub)
+
+    for _ in range(1500):
+        before = state.round_state.score
+        key, action_key, step_key = jax.random.split(key, 3)
+        action = jax.random.categorical(
+            action_key, jnp.log(jnp.where(state.legal_action_mask, 1.0, 0.0))
+        )
+        state = step(state, action.astype(jnp.int8), step_key)
+        delta = (state.round_state.score - before).astype(jnp.float32)
+        assert jnp.allclose(state.rewards, delta), (
+            f"rewards {state.rewards} but the score moved by {delta}"
+        )
+        if bool(state.terminated) or bool(state.truncated):
+            break

--- a/tests/no_red_mahjong/test_env.py
+++ b/tests/no_red_mahjong/test_env.py
@@ -1663,7 +1663,7 @@ def test_no_red_uma_scales_a_custom_order_points() -> None:
     assert jnp.array_equal(out.round_state.score - before, jnp.array([200, 50, -50, -200]))
 
 
-def _temporary_furiten_after_declining_then_an_unrelated_pass(m, Action):
+def _furiten_by_pass_after_declining_then_an_unrelated_pass(m, Action):
     """X declines a winning discard, then passes on an unrelated PON before drawing."""
     base = m.default_state()
     x = 1
@@ -1687,10 +1687,10 @@ def _temporary_furiten_after_declining_then_an_unrelated_pass(m, Action):
     return x, declined, unrelated
 
 
-def test_no_red_temporary_furiten_survives_an_unrelated_pass() -> None:
+def test_no_red_furiten_by_pass_survives_an_unrelated_pass() -> None:
     from mahjax.no_red_mahjong import env as m
 
-    x, declined, unrelated = _temporary_furiten_after_declining_then_an_unrelated_pass(m, Action)
+    x, declined, unrelated = _furiten_by_pass_after_declining_then_an_unrelated_pass(m, Action)
 
     assert bool(declined.players.furiten_by_pass[x])
     assert bool(unrelated.players.furiten_by_pass[x])

--- a/tests/red_mahjong/test_env.py
+++ b/tests/red_mahjong/test_env.py
@@ -13,6 +13,7 @@ from mahjax.red_mahjong.env import (
     _mask_for_chi,
     _next_meld_player,
     _next_ron_player,
+    _pass,
     _advance_to_next_round_auto,
     _replace_state,
     _step,
@@ -363,7 +364,7 @@ def test_red_auto_single_mode_terminates_like_legacy() -> None:
 
 
 def test_red_auto_game_end_sets_terminated_with_final_score() -> None:
-    env_auto = RedMahjong(round_mode="half", next_round_style="auto")
+    env_auto = RedMahjong(round_mode="half", next_round_style="auto", order_points=[300, 100, -100, -300])
     state = env_auto.init(jax.random.PRNGKey(3))
     state = _replace_state(
         state,
@@ -456,8 +457,8 @@ def test_red_auto_matches_dummy_share_at_game_end() -> None:
     Compare the two terminal states: same ``terminated``, same final ``score``,
     same ``rewards``.
     """
-    env_auto = RedMahjong(round_mode="half", next_round_style="auto")
-    env_share = RedMahjong(round_mode="half", next_round_style="dummy_share")
+    env_auto = RedMahjong(round_mode="half", next_round_style="auto", order_points=[300, 100, -100, -300])
+    env_share = RedMahjong(round_mode="half", next_round_style="dummy_share", order_points=[300, 100, -100, -300])
     key = jax.random.PRNGKey(2026)
     forced = dict(
         dealer=jnp.int8(0),
@@ -473,13 +474,16 @@ def test_red_auto_matches_dummy_share_at_game_end() -> None:
     state_share = _replace_state(_force_ron_state(env_share, key), **forced)
 
     state_auto = env_auto.step(state_auto, jnp.int32(Action.RON), STEP_KEY)
+    total_auto = state_auto.rewards
     state_share = env_share.step(state_share, jnp.int32(Action.RON), STEP_KEY)
+    total_share = state_share.rewards
     state_share = env_share.step(state_share, jnp.int32(Action.DUMMY), STEP_KEY)
+    total_share = total_share + state_share.rewards
 
     assert bool(state_auto.terminated)
     assert bool(state_share.terminated)
     assert bool(jnp.all(state_auto.round_state.score == state_share.round_state.score))
-    assert bool(jnp.all(state_auto.rewards == state_share.rewards))
+    assert bool(jnp.all(total_auto == total_share))
 
 
 def test_calc_wind_assigns_east_to_dealer() -> None:
@@ -574,7 +578,7 @@ def test_red_sudden_death_runs_for_exactly_four_extra_rounds() -> None:
 
 
 def test_red_uma_is_added_to_the_final_score() -> None:
-    env = RedMahjong(round_mode="half", next_round_style="auto")
+    env = RedMahjong(round_mode="half", next_round_style="auto", order_points=[300, 100, -100, -300])
     before = jnp.array([310, 300, 200, 190], dtype=jnp.int32)
     state = _end_of_round_state(env, score=before)
 
@@ -585,7 +589,7 @@ def test_red_uma_is_added_to_the_final_score() -> None:
 
 
 def test_red_dummy_share_applies_uma_when_a_non_dealer_won_the_final_round() -> None:
-    env = RedMahjong(round_mode="half", next_round_style="dummy_share")
+    env = RedMahjong(round_mode="half", next_round_style="dummy_share", order_points=[300, 100, -100, -300])
     state = _end_of_round_state(
         env,
         score=jnp.array([200, 300, 260, 240], dtype=jnp.int32),
@@ -608,3 +612,102 @@ def test_red_uma_scales_a_custom_order_points() -> None:
     out = _advance_to_next_round_auto(state, jax.random.PRNGKey(0))
 
     assert jnp.array_equal(out.round_state.score - before, jnp.array([200, 50, -50, -200]))
+
+
+def _temporary_furiten_after_declining_then_an_unrelated_pass(m, Action):
+    """X declines a winning discard, then passes on an unrelated PON before drawing."""
+    base = m.default_state()
+    x = 1
+    mask = base.players.legal_action_mask
+    declined = m._pass(
+        m._replace_state(
+            base,
+            current_player=jnp.int8(x),
+            last_player=jnp.int8(0),
+            legal_action_mask=mask.at[x, Action.RON].set(True).at[x, Action.PASS].set(True),
+        )
+    )
+    unrelated = m._pass(
+        m._replace_state(
+            declined,
+            current_player=jnp.int8(x),
+            last_player=jnp.int8(2),
+            legal_action_mask=mask.at[x, Action.PON].set(True).at[x, Action.PASS].set(True),
+        )
+    )
+    return x, declined, unrelated
+
+
+def test_red_temporary_furiten_survives_an_unrelated_pass() -> None:
+    from mahjax.red_mahjong import env as m
+
+    x, declined, unrelated = _temporary_furiten_after_declining_then_an_unrelated_pass(m, Action)
+
+    assert bool(declined.players.furiten_by_pass[x])
+    assert bool(unrelated.players.furiten_by_pass[x])
+    # It still clears on the player own next draw, unless they are in riichi.
+    drawn = _draw(_replace_state(unrelated, current_player=jnp.int8(x), draw_next=True))
+    assert not bool(drawn.players.furiten_by_pass[x])
+    riichi = _draw(
+        _replace_state(
+            unrelated,
+            current_player=jnp.int8(x),
+            draw_next=True,
+            riichi=unrelated.players.riichi.at[x].set(True),
+        )
+    )
+    assert bool(riichi.players.furiten_by_pass[x])
+
+
+def test_red_rewards_report_only_the_current_transition() -> None:
+    env = RedMahjong(round_mode="east", next_round_style="dummy_share")
+    step = jax.jit(env.step)
+    key = jax.random.PRNGKey(11)
+    key, sub = jax.random.split(key)
+    state = env.init(sub)
+
+    for _ in range(1500):
+        before = state.round_state.score
+        key, action_key, step_key = jax.random.split(key, 3)
+        action = jax.random.categorical(
+            action_key, jnp.log(jnp.where(state.legal_action_mask, 1.0, 0.0))
+        )
+        state = step(state, action.astype(jnp.int8), step_key)
+        delta = (state.round_state.score - before).astype(jnp.float32)
+        assert jnp.allclose(state.rewards, delta), (
+            f"rewards {state.rewards} but the score moved by {delta}"
+        )
+        if bool(state.terminated) or bool(state.truncated):
+            break
+
+
+def test_red_multi_ron_reward_stream_matches_the_score_movement() -> None:
+    env = RedMahjong(round_mode="single", next_round_style="auto")
+    base = default_state()
+    legal_action_mask = base.players.legal_action_mask
+    for player in range(3):
+        legal_action_mask = legal_action_mask.at[player, Action.RON].set(True)
+    state = base.replace(
+        current_player=jnp.int8(0),
+        legal_action_mask=legal_action_mask[0],
+        players=base.players.replace(
+            legal_action_mask=legal_action_mask,
+            fan=base.players.fan.at[:, 0].set(jnp.int32(5)),
+            fu=base.players.fu.at[:, 0].set(jnp.int32(30)),
+        ),
+        round_state=base.round_state.replace(
+            dealer=jnp.int8(3),
+            last_player=jnp.int8(3),
+            honba=jnp.int8(1),
+            kyotaku=jnp.int8(2),
+            score=jnp.array([250, 250, 250, 250], dtype=jnp.int32),
+        ),
+    )
+    start = state.round_state.score
+    total = jnp.zeros(4, dtype=jnp.float32)
+
+    for action in (Action.RON, Action.PASS):
+        state = env.step(state, jnp.int8(action), STEP_KEY)
+        total = total + state.rewards
+
+    assert jnp.allclose(total, (state.round_state.score - start).astype(jnp.float32))

--- a/tests/red_mahjong/test_env.py
+++ b/tests/red_mahjong/test_env.py
@@ -614,7 +614,7 @@ def test_red_uma_scales_a_custom_order_points() -> None:
     assert jnp.array_equal(out.round_state.score - before, jnp.array([200, 50, -50, -200]))
 
 
-def _temporary_furiten_after_declining_then_an_unrelated_pass(m, Action):
+def _furiten_by_pass_after_declining_then_an_unrelated_pass(m, Action):
     """X declines a winning discard, then passes on an unrelated PON before drawing."""
     base = m.default_state()
     x = 1
@@ -638,10 +638,10 @@ def _temporary_furiten_after_declining_then_an_unrelated_pass(m, Action):
     return x, declined, unrelated
 
 
-def test_red_temporary_furiten_survives_an_unrelated_pass() -> None:
+def test_red_furiten_by_pass_survives_an_unrelated_pass() -> None:
     from mahjax.red_mahjong import env as m
 
-    x, declined, unrelated = _temporary_furiten_after_declining_then_an_unrelated_pass(m, Action)
+    x, declined, unrelated = _furiten_by_pass_after_declining_then_an_unrelated_pass(m, Action)
 
     assert bool(declined.players.furiten_by_pass[x])
     assert bool(unrelated.players.furiten_by_pass[x])
@@ -711,3 +711,25 @@ def test_red_multi_ron_reward_stream_matches_the_score_movement() -> None:
         total = total + state.rewards
 
     assert jnp.allclose(total, (state.round_state.score - start).astype(jnp.float32))
+
+
+def test_red_furiten_by_pass_clears_when_a_meld_gives_the_turn() -> None:
+    """A pon takes the turn without a draw, so it must clear the furiten by pass."""
+    from mahjax.red_mahjong import env as m
+
+    x, declined, _ = _furiten_by_pass_after_declining_then_an_unrelated_pass(m, Action)
+    hand = jnp.zeros((37,), dtype=jnp.int8).at[0].set(3).at[1].set(3).at[2].set(3).at[3].set(3)
+    ponned = m._pon(
+        _replace_state(
+            declined,
+            current_player=jnp.int8(x),
+            last_player=jnp.int8(0),
+            target=jnp.int8(0),
+            hand_with_red=declined.players.hand_with_red.at[x].set(hand),
+            hand=declined.players.hand.at[x].set(Hand.to_34(hand)),
+        ),
+        jnp.int8(Action.PON),
+    )
+
+    assert bool(declined.players.furiten_by_pass[x])
+    assert not bool(ponned.players.furiten_by_pass[x])

--- a/tests/red_mahjong/test_parity.py
+++ b/tests/red_mahjong/test_parity.py
@@ -416,7 +416,7 @@ def test_double_ron_config_chains_ron_and_pass_resolution() -> None:
     assert int(after_pass.round_state.kyotaku) == 0
     assert jnp.array_equal(
         after_pass.round_state.score,
-        jnp.int32(ron_state.round_state.score + after_first_ron.rewards),
+        jnp.int32(ron_state.round_state.score + after_first_ron.pending_rewards),
     )
 
 


### PR DESCRIPTION
## 1. `rewards` kept reporting the previous payout

Nothing cleared `rewards` on an ordinary step, so the last payment stayed in the vector until the next payment overwrote it. A learner that sums rewards per step counted the same payout several times. `score` was always right, which is why this went unnoticed.

`Env.step` now clears `rewards` before running the step. Two consequences:

- The multi-ron chain used `rewards` as a cross-step buffer for the first ron's pending payment (added in #77). Clearing it there would delete the payment outright, so the buffer moved to a new `pending_rewards` field. `no_red_mahjong` has no multi-ron and only carries the field for schema parity.
- The game-end rank-point and riichi-stick settlement was never reported at all. It is now, so `rewards` equals the score movement of the step on every step, with no exceptions left.


**Breaking:** the default `order_points` is now `[0, 0, 0, 0]`. With the game-end settlement reaching `rewards`, uma would otherwise dominate the reward scale by default. Pass `[300, 100, -100, -300]` for 10-30 uma.

## 2. Furiten by pass did not last a full go-around

Two halves, both rule violations.

- **It was wiped by an unrelated pass.** `_pass` assigned `furiten_by_pass` instead of OR-ing it, so a player who declined a winning discard lost that furiten as soon as they passed on an unrelated pon or chi, and could then ron a tile they had already declined. Six one-line changes, four in red and two in no_red. The change is monotone: it can only leave the flag set where the old code cleared it, so it can never make an illegal ron legal. It also fixes a quieter case of the same bug, where declining a robbable kan wiped an existing flag.

- **It was not cleared when a meld gave the turn.** The flag was only cleared in `_draw`, so a player who declined and then ponned, chied or called an open kan stayed furiten past their own turn, all the way to their next natural draw. The clear now happens at every turn start: `_draw` as before, plus `_pon`, `_chi` and `_open_kan` through a shared `_clear_furiten_by_pass` helper.

Clearing at the turn start rather than at the discard is deliberate: the policy needs `obs["furiten"]` to be correct while it is choosing what to discard.

Riichi still keeps the player furiten for the rest of the round, on every path, since all four sites use the same `furiten_by_pass[c_p] & riichi[c_p]`.

`_draw_after_kan` needs no clear. A closed or added kan happens during a turn that already began with a draw, and an open kan goes through `_open_kan`.

## Tests

Five new tests, all failing on `main`, plus regression coverage for the meld paths. Nine existing expectations updated: the uma tests now state the `order_points` they test, and the auto/dummy_share parity tests compare summed rewards instead of the terminal vector, because the two styles now spread the same total over a different number of steps.

`tests/no_red_mahjong/test_play.py` fails the same way on `main` and is excluded from CI.
